### PR TITLE
[BACKLOG-3358] A starting implementation of a

### DIFF
--- a/pentaho-cache-manager/impl/ehcache/pom.xml
+++ b/pentaho-cache-manager/impl/ehcache/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>pentaho-cache-manager-parent</artifactId>
+        <groupId>pentaho</groupId>
+        <version>6.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>pentaho-ehcache-provider</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>Pentaho Cache Manager: ehcache Cache Provider</name>
+    <description>a Pentaho open source project</description>
+    <url>http://www.pentaho.com</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>pentaho</groupId>
+            <artifactId>pentaho-cache-manager-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
+            <version>2.8.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ehcache</groupId>
+            <artifactId>jcache</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pentaho-cache-manager/impl/ehcache/src/main/java/org/pentaho/caching/ehcache/EhcacheProvidingService.java
+++ b/pentaho-cache-manager/impl/ehcache/src/main/java/org/pentaho/caching/ehcache/EhcacheProvidingService.java
@@ -1,0 +1,50 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.caching.ehcache;
+
+import org.ehcache.jcache.JCacheCachingProvider;
+import org.ehcache.jcache.JCacheManager;
+import org.pentaho.caching.api.PentahoCacheSystemConfiguration;
+import org.pentaho.caching.spi.AbstractCacheProvidingService;
+
+import java.net.URI;
+import java.util.Properties;
+
+/**
+ *  PentahoCacheProvidingService implementation which leverages the
+ *  org.ehcache.jcache project to provide a JCache CacheManager wrapping
+ *  ehcache 2.x. Once we move to ehcache 3.x we'll no longer need the wrapper.
+ */
+public class EhcacheProvidingService extends AbstractCacheProvidingService {
+
+  private static final JCacheCachingProvider providerInstance = new JCacheCachingProvider();
+
+  @Override public javax.cache.CacheManager createCacheManager( PentahoCacheSystemConfiguration systemConfiguration ) {
+    return new JCacheManager(
+        providerInstance,
+        net.sf.ehcache.CacheManager.getInstance(),
+        URI.create( getClass().getName() ),
+        new Properties() );
+  }
+
+}

--- a/pentaho-cache-manager/impl/ehcache/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/pentaho-cache-manager/impl/ehcache/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <service id="cacheProvidingService" interface="org.pentaho.caching.api.PentahoCacheProvidingService">
+        <service-properties>
+            <entry key="pentaho.cache.provider" value="org.pentaho.caching.ehcache.EhcacheProvidingService"/>
+        </service-properties>
+        <bean class="org.pentaho.caching.ehcache.EhcacheProvidingService" />
+    </service>
+
+</blueprint>

--- a/pentaho-cache-manager/impl/ehcache/src/test/java/org/pentaho/caching/ehcache/EhcacheProvidingServiceTest.java
+++ b/pentaho-cache-manager/impl/ehcache/src/test/java/org/pentaho/caching/ehcache/EhcacheProvidingServiceTest.java
@@ -1,0 +1,46 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.caching.ehcache;
+
+import org.junit.Test;
+import org.pentaho.caching.api.PentahoCacheSystemConfiguration;
+
+import javax.cache.CacheManager;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+public class EhcacheProvidingServiceTest {
+
+  private EhcacheProvidingService service = new EhcacheProvidingService();
+
+  @Test public void testCreateCacheManager() throws Exception {
+    CacheManager cacheManager = service.createCacheManager( mock( PentahoCacheSystemConfiguration.class ) );
+    assertNotNull( cacheManager );
+    try {
+      cacheManager.unwrap( net.sf.ehcache.CacheManager.class );
+    } catch ( IllegalArgumentException iae ) {
+      fail( "Expected CacheManager to be backed by ehcache CacheManager." );
+    }
+  }
+}


### PR DESCRIPTION
PentahoCacheProvidingService for ehcache which supplies a JCache
CacheManager wrapping ehcache 2.x.  This provider will need to be
enhanced to support configuration of non-jcache covered features
(e.g. memory sizing and cache storage).