### PR TITLE
[BISERVER-12772] Ensure toRelativePathedObject is always called

### DIFF
--- a/pentaho-requirejs-osgi-manager/src/main/java/org/pentaho/js/require/RebuildCacheCallable.java
+++ b/pentaho-requirejs-osgi-manager/src/main/java/org/pentaho/js/require/RebuildCacheCallable.java
@@ -89,7 +89,7 @@ public class RebuildCacheCallable implements Callable<String> {
     } else {
       if ( value1 instanceof JSONObject ) {
         if ( value2 instanceof JSONObject ) {
-          return merge( (JSONObject) value1, (JSONObject) value2 );
+          return merge( (JSONObject) value1, toRelativePathedObject( (JSONObject) value2 ) );
         } else {
           throw new Exception( "Cannot merge key " + key + " due to different types." );
         }

--- a/pentaho-requirejs-osgi-manager/src/test/java/org/pentaho/js/require/RebuildCacheCallableTest.java
+++ b/pentaho-requirejs-osgi-manager/src/test/java/org/pentaho/js/require/RebuildCacheCallableTest.java
@@ -189,4 +189,36 @@ public class RebuildCacheCallableTest {
     object2.put( new Object(), new JSONArray() );
     String config = new RebuildCacheCallable( configMap, requireJsConfigurations ).call();
   }
+
+  @Test
+  public void testRelativePathConversion() throws Exception {
+    String objectKey = "object";
+    String moduleKey = "module";
+    String modulePath = "module/path/script";
+
+    Map<Long, JSONObject> configMap = new HashMap<Long, JSONObject>();
+
+    JSONObject object1 = new JSONObject();
+    configMap.put( 1L, object1 );
+
+    JSONObject relativePath = new JSONObject();
+    relativePath.put(moduleKey, modulePath);
+
+    object1.put( objectKey, relativePath );
+
+    JSONObject object2 = new JSONObject();
+    configMap.put( 2L, object2 );
+
+    JSONObject absolutePath = new JSONObject();
+    absolutePath.put(moduleKey, "/" + modulePath);
+
+    object2.put( objectKey, absolutePath );
+
+    String config = new RebuildCacheCallable( configMap, requireJsConfigurations ).call();
+    if ( config.endsWith( ";" ) ) {
+      config = config.substring( 0, config.length() - 1 );
+    }
+    Object configValue = JSONValue.parse( config );
+    testEquals( modulePath, ( (JSONObject) ( (JSONObject) configValue ).get( objectKey ) ).get( moduleKey ) );
+  }
 }


### PR DESCRIPTION
When duplicate requires are defined, absolute paths from require.json in a OSGI bundle are not properly converted to relative paths.

For review. @CodeOnCoffee @pentaho-nbaker