### PR TITLE
[BACKLOG-4439] Create SAML Implementation using Spring 4 as a Reference Implementation

### DIFF
--- a/pentaho-ss2-proxies/src/main/java/org/pentaho/proxy/creators/ProxyCreatorActivator.java
+++ b/pentaho-ss2-proxies/src/main/java/org/pentaho/proxy/creators/ProxyCreatorActivator.java
@@ -8,6 +8,7 @@ import org.pentaho.proxy.creators.authenticationentrypoint.AuthenticationExcepti
 import org.pentaho.proxy.creators.authenticationmanager.AuthenticationManagerProxyCreator;
 import org.pentaho.proxy.creators.authenticationprovider.AuthenticationProviderProxyCreator;
 import org.pentaho.proxy.creators.authenticationprovider.AuthenticationProxyCreator;
+import org.pentaho.proxy.creators.grantedauthorities.GrantedAuthorityProxyCreator;
 import org.pentaho.proxy.creators.securitycontext.SecurityContextProxyCreator;
 import org.pentaho.proxy.creators.userdetailsservice.UserDetailsServiceCreator;
 
@@ -24,6 +25,7 @@ public class ProxyCreatorActivator implements BundleActivator {
     bundleContext.registerService( IProxyCreator.class, new AuthenticationExceptionProxyCreator(), null );
     bundleContext.registerService( IProxyCreator.class, new AuthenticationManagerProxyCreator(), null );
     bundleContext.registerService( IProxyCreator.class, new SecurityContextProxyCreator(), null );
+    bundleContext.registerService( IProxyCreator.class, new GrantedAuthorityProxyCreator(), null );
   }
 
   @Override public void stop( BundleContext bundleContext ) throws Exception {

--- a/pentaho-ss2-proxies/src/main/java/org/pentaho/proxy/creators/grantedauthorities/GrantedAuthorityProxyCreator.java
+++ b/pentaho-ss2-proxies/src/main/java/org/pentaho/proxy/creators/grantedauthorities/GrantedAuthorityProxyCreator.java
@@ -1,0 +1,77 @@
+package org.pentaho.proxy.creators.grantedauthorities;
+
+import org.pentaho.platform.proxy.api.IProxyCreator;
+import org.pentaho.platform.proxy.api.IProxyFactory;
+import org.pentaho.proxy.creators.ProxyUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.GrantedAuthority;
+
+
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class GrantedAuthorityProxyCreator implements IProxyCreator<GrantedAuthority> {
+
+  private Logger logger = LoggerFactory.getLogger( getClass() );
+
+  @Override public boolean supports( Class aClass ) {
+    return ProxyUtils.isRecursivelySupported( "org.springframework.security.core.GrantedAuthority", aClass );
+  }
+
+  @Override public GrantedAuthority create( Object o ) {
+    return new ProxyGrantedAuthority( o );
+  }
+
+  protected IProxyFactory getProxyFactory() {
+    return ProxyUtils.getInstance().getProxyFactory();
+  }
+
+  private class ProxyGrantedAuthority implements GrantedAuthority {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 1603112902745163281L;
+
+    private Object target;
+
+    private Method getAuthorityMethod;
+
+    public ProxyGrantedAuthority( Object target ) {
+      this.target = target;
+    }
+
+    @Override
+    public String getAuthority() {
+      try {
+
+        if ( getAuthorityMethod == null ) {
+          getAuthorityMethod = ProxyUtils.findMethodByName( target.getClass(), "getAuthority" );
+        }
+
+        return (String) getAuthorityMethod.invoke( target );
+
+      } catch ( InvocationTargetException | IllegalAccessException e ) {
+        logger.error( e.getMessage() , e );
+      }
+
+      return null;
+    }
+
+    @Override
+    public int compareTo( Object o ) {
+      if ( o != null && o instanceof GrantedAuthority ) {
+        String rhsRole = ( (GrantedAuthority) o ).getAuthority();
+
+        if ( rhsRole == null ) {
+          return -1;
+        }
+        return getAuthority().compareTo( rhsRole );
+      }
+      return -1;
+    }
+  }
+
+}

--- a/pentaho-ss2-proxies/src/test/java/org/pentaho/proxy/creators/grantedauthorities/GrantedAuthorityProxyCreatorTest.java
+++ b/pentaho-ss2-proxies/src/test/java/org/pentaho/proxy/creators/grantedauthorities/GrantedAuthorityProxyCreatorTest.java
@@ -1,0 +1,78 @@
+package org.pentaho.proxy.creators.grantedauthorities;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.platform.proxy.api.IProxyFactory;
+import org.pentaho.platform.proxy.api.IProxyRegistration;
+import org.pentaho.platform.proxy.impl.ProxyException;
+
+import org.pentaho.proxy.creators.grantedauthorities.GrantedAuthorityProxyCreator;
+import org.springframework.security.GrantedAuthority;
+
+import java.util.List;
+import java.util.Map;
+
+public class GrantedAuthorityProxyCreatorTest {
+
+  private static final String MOCK_ROLE_AUTHENTICATED = "MockRoleAuthenticated";
+
+  private GrantedAuthority mockGrantedAuthority;
+
+  @Before
+  public void setUp() throws NoSuchMethodException {
+
+    mockGrantedAuthority = new GrantedAuthority() {
+      @Override public String getAuthority() {
+        return MOCK_ROLE_AUTHENTICATED;
+      }
+
+      @Override public int compareTo( Object o ) {
+        if ( o != null && o instanceof GrantedAuthority ) {
+          String rhsRole = ( (GrantedAuthority) o ).getAuthority();
+
+          if ( rhsRole == null ) {
+            return -1;
+          }
+          return getAuthority().compareTo( rhsRole );
+        }
+        return -1;
+      }
+    };
+  }
+
+  @Test public void testCreateProxyWrapper() {
+
+    GrantedAuthority wrappedObject = new GrantedAuthoritiesProxyCreatorForTest().create( mockGrantedAuthority );
+
+    Assert.assertNotNull( wrappedObject );
+    Assert.assertTrue( MOCK_ROLE_AUTHENTICATED.equals( wrappedObject.getAuthority() ) );
+  }
+
+  @After
+  public void tearDown() {
+    mockGrantedAuthority = null;
+  }
+
+  private class GrantedAuthoritiesProxyCreatorForTest extends GrantedAuthorityProxyCreator {
+
+    @Override public boolean supports( Class aClass ) {
+      return true;
+    }
+
+    @Override public IProxyFactory getProxyFactory() {
+      return new IProxyFactory(){
+
+        @Override public <T, K> IProxyRegistration createAndRegisterProxy( T target, List<Class<?>> publishedClasses,
+            Map<String, Object> properties ) throws ProxyException {
+          return null;
+        }
+
+        @Override public <T, K> K createProxy( T target ) throws ProxyException {
+          return ( K ) target;
+        }
+      };
+    }
+  }
+}

--- a/pentaho-ss4-proxies/src/main/java/org/pentaho/proxy/creators/grantedauthorities/S4GrantedAuthorityProxyCreator.java
+++ b/pentaho-ss4-proxies/src/main/java/org/pentaho/proxy/creators/grantedauthorities/S4GrantedAuthorityProxyCreator.java
@@ -1,0 +1,66 @@
+package org.pentaho.proxy.creators.grantedauthorities;
+
+import org.pentaho.platform.proxy.api.IProxyCreator;
+import org.pentaho.platform.proxy.api.IProxyFactory;
+import org.pentaho.proxy.creators.ProxyUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.GrantedAuthority;
+
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class S4GrantedAuthorityProxyCreator implements IProxyCreator<GrantedAuthority> {
+
+  private Logger logger = LoggerFactory.getLogger( getClass() );
+
+  @Override public boolean supports( Class aClass ) {
+    // supports legacy spring.security 2.0.8 SecurityContext
+    return ProxyUtils.isRecursivelySupported( "org.springframework.security.GrantedAuthority", aClass );
+  }
+
+  @Override public GrantedAuthority create( Object o ) {
+    return new ProxyGrantedAuthority( o );
+  }
+
+  protected IProxyFactory getProxyFactory() {
+    return ProxyUtils.getInstance().getProxyFactory();
+  }
+
+  private class ProxyGrantedAuthority implements GrantedAuthority {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 1603112902745163281L;
+
+    private Object target;
+
+    private Method getAuthorityMethod;
+
+    public ProxyGrantedAuthority( Object target ) {
+      this.target = target;
+    }
+
+    @Override
+    public String getAuthority() {
+      try {
+
+        if ( getAuthorityMethod == null ) {
+          getAuthorityMethod = ProxyUtils.findMethodByName( target.getClass(), "getAuthority" );
+        }
+
+        return (String) getAuthorityMethod.invoke( target );
+
+      } catch ( InvocationTargetException | IllegalAccessException e ) {
+        logger.error( e.getMessage() , e );
+      }
+
+      return null;
+    }
+
+
+  }
+
+}

--- a/pentaho-ss4-proxies/src/main/resources/OSGI-INF/blueprint/beans.xml
+++ b/pentaho-ss4-proxies/src/main/resources/OSGI-INF/blueprint/beans.xml
@@ -38,4 +38,8 @@
 	<service auto-export="all-classes">
 		<bean class="org.pentaho.proxy.creators.securitycontext.S4SecurityContextProxyCreator" />
 	</service>
+
+	<service auto-export="all-classes">
+		<bean class="org.pentaho.proxy.creators.grantedauthorities.S4GrantedAuthorityProxyCreator" />
+	</service>
 </blueprint>

--- a/pentaho-ss4-proxies/src/test/java/org/pentaho/proxy/creators/grantedauthorities/S4GrantedAuthorityProxyCreatorTest.java
+++ b/pentaho-ss4-proxies/src/test/java/org/pentaho/proxy/creators/grantedauthorities/S4GrantedAuthorityProxyCreatorTest.java
@@ -1,0 +1,66 @@
+package org.pentaho.proxy.creators.grantedauthorities;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.platform.proxy.api.IProxyFactory;
+import org.pentaho.platform.proxy.api.IProxyRegistration;
+import org.pentaho.platform.proxy.impl.ProxyException;
+
+import org.pentaho.proxy.creators.grantedauthorities.S4GrantedAuthorityProxyCreator;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.List;
+import java.util.Map;
+
+public class S4GrantedAuthorityProxyCreatorTest {
+
+  private static final String MOCK_ROLE_AUTHENTICATED = "MockRoleAuthenticated";
+
+  private GrantedAuthority mockGrantedAuthority;
+
+  @Before
+  public void setUp() throws NoSuchMethodException {
+
+    mockGrantedAuthority = new GrantedAuthority() {
+      @Override public String getAuthority() {
+        return MOCK_ROLE_AUTHENTICATED;
+      }
+    };
+  }
+
+  @Test public void testCreateProxyWrapper() {
+
+    GrantedAuthority wrappedObject = new S4GrantedAuthoritiesProxyCreatorForTest().create( mockGrantedAuthority );
+
+    Assert.assertNotNull( wrappedObject );
+    Assert.assertTrue( MOCK_ROLE_AUTHENTICATED.equals( wrappedObject.getAuthority() ) );
+  }
+
+  @After
+  public void tearDown() {
+    mockGrantedAuthority = null;
+  }
+
+  private class S4GrantedAuthoritiesProxyCreatorForTest extends S4GrantedAuthorityProxyCreator {
+
+    @Override public boolean supports( Class aClass ) {
+      return true;
+    }
+
+    @Override public IProxyFactory getProxyFactory() {
+      return new IProxyFactory(){
+
+        @Override public <T, K> IProxyRegistration createAndRegisterProxy( T target, List<Class<?>> publishedClasses,
+            Map<String, Object> properties ) throws ProxyException {
+          return null;
+        }
+
+        @Override public <T, K> K createProxy( T target ) throws ProxyException {
+          return ( K ) target;
+        }
+      };
+    }
+  }
+}


### PR DESCRIPTION
Created a new ProxyCreator for the GrantedAuthority spring object

	- there are situations where the GrantedAuthorities are being fetched directly ( i.e. being fetched from the IPentahoSession.SESSION_ROLES ) and not via a ( already proxy-wrapped ) UserDetails
	- example: reports with a mondrian datasource: https://github.com/pentaho/pentaho-platform/blob/6.0.0.0-R/extensions/src/org/pentaho/platform/plugin/action/mondrian/mapper/MondrianAbstractPlatformUserRoleMapper.java#L153
	- added unit tests