### PR TITLE
[BISERVER-12921] Implement Global Logout in SAML

### DIFF
--- a/pentaho-ss2-proxies/src/main/java/org/pentaho/proxy/creators/securitycontext/SecurityContextProxyCreator.java
+++ b/pentaho-ss2-proxies/src/main/java/org/pentaho/proxy/creators/securitycontext/SecurityContextProxyCreator.java
@@ -66,13 +66,18 @@ public class SecurityContextProxyCreator implements IProxyCreator<SecurityContex
 
       try {
 
-        Object auth = ProxyUtils.getInstance().getProxyFactory().createProxy( authentication );
+        if( authentication == null ) {
 
-        if ( setAuthenticationMethod == null ) {
+          setAuthenticationMethod = ProxyUtils.findMethodByName( target.getClass(), "setAuthentication" );
+          setAuthenticationMethod.invoke( target, null );
+
+        } else {
+
+          Object auth = ProxyUtils.getInstance().getProxyFactory().createProxy( authentication );
           setAuthenticationMethod = ProxyUtils.findMethodByName( target.getClass(), "setAuthentication", auth.getClass() );
-        }
 
-        setAuthenticationMethod.invoke( target, auth );
+          setAuthenticationMethod.invoke( target, auth );
+        }
 
       } catch ( InvocationTargetException | IllegalAccessException | ProxyException e ) {
         logger.error( e.getMessage() , e );

--- a/pentaho-ss4-proxies/src/main/java/org/pentaho/proxy/creators/authenticationprovider/S4AuthenticationProxyCreator.java
+++ b/pentaho-ss4-proxies/src/main/java/org/pentaho/proxy/creators/authenticationprovider/S4AuthenticationProxyCreator.java
@@ -5,9 +5,15 @@ import org.pentaho.platform.proxy.api.IProxyCreator;
 import org.pentaho.platform.proxy.api.IProxyFactory;
 import org.pentaho.platform.proxy.impl.ProxyException;
 import org.pentaho.proxy.creators.ProxyUtils;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.util.ReflectionUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +49,51 @@ public class S4AuthenticationProxyCreator implements IProxyCreator<Authenticatio
       } catch ( InvocationTargetException e ) {
         logger.error( e.getMessage() , e );
       }
+    } else if( "org.springframework.security.providers.anonymous.AnonymousAuthenticationToken".equals( className ) ) {
+
+      Method getKeyHash = ReflectionUtils.findMethod( o.getClass(), "getKeyHash" );
+      Method getDetails = ReflectionUtils.findMethod( o.getClass(), "getDetails" );
+      Method getPrincipal = ReflectionUtils.findMethod( o.getClass(), "getPrincipal" );
+      Method getAuthorities = ReflectionUtils.findMethod( o.getClass(), "getAuthorities" );
+
+      try {
+
+        getKeyHash.setAccessible( true );
+        getDetails.setAccessible( true );
+        getPrincipal.setAccessible( true );
+        getAuthorities.setAccessible( true );
+
+        Object keyHash = getKeyHash.invoke( o );
+        Object details = getDetails.invoke( o );
+        Object principal = getPrincipal.invoke( o );
+        Object authoritiesObj = getAuthorities.invoke( o );
+
+        Collection<SimpleGrantedAuthority> s4Authorities = new ArrayList<SimpleGrantedAuthority>();
+
+        if( authoritiesObj != null && authoritiesObj instanceof Object[] ){
+
+          for( Object authorityObj : ( Object[] ) authoritiesObj ){
+
+            Method getAuthority = ReflectionUtils.findMethod( authorityObj.getClass(), "getAuthority" );
+            Object authority = getAuthority.invoke( authorityObj );
+            if( authority != null ) {
+              s4Authorities.add( new SimpleGrantedAuthority( authority.toString() ) );
+            }
+          }
+        }
+
+        AnonymousAuthenticationToken anonymousToken =
+            new AnonymousAuthenticationToken( keyHash.toString(), principal, s4Authorities );
+        anonymousToken.setDetails( details );
+
+        return anonymousToken;
+
+      } catch ( IllegalAccessException | InvocationTargetException e ) {
+        logger.error( e.getMessage(), e );
+      }
+
     }
+
     return null;
   }
 

--- a/pentaho-ss4-proxies/src/main/java/org/pentaho/proxy/creators/securitycontext/S4SecurityContextProxyCreator.java
+++ b/pentaho-ss4-proxies/src/main/java/org/pentaho/proxy/creators/securitycontext/S4SecurityContextProxyCreator.java
@@ -66,13 +66,19 @@ public class S4SecurityContextProxyCreator implements IProxyCreator<SecurityCont
 
       try {
 
-        Object auth = ProxyUtils.getInstance().getProxyFactory().createProxy( authentication );
+        if( authentication == null ) {
 
-        if ( setAuthenticationMethod == null ) {
+          setAuthenticationMethod = ProxyUtils.findMethodByName( target.getClass(), "setAuthentication" );
+          setAuthenticationMethod.invoke( target, null );
+
+        } else {
+
+          Object auth = ProxyUtils.getInstance().getProxyFactory().createProxy( authentication );
+
           setAuthenticationMethod = ProxyUtils.findMethodByName( target.getClass(), "setAuthentication", auth.getClass() );
-        }
+          setAuthenticationMethod.invoke( target, auth );
 
-        setAuthenticationMethod.invoke( target, auth );
+        }
 
       } catch ( InvocationTargetException | IllegalAccessException | ProxyException e ) {
         logger.error( e.getMessage() , e );


### PR DESCRIPTION
	- safeguarded SecurityContextProxyCreator / S4SecurityContextProxyCreator against possible NPE's ( when calls to SecurityContextHelper.getContext().setAuthentication( null ) are made )
	- AuthenticationProxyCreator / S4AuthenticationProxyCreator so far only allowed for the proxy-wrapping of "UsernamePasswordAuthenticationToken"; I expanded it to also allow for the wrapping of "AnonymousAuthenticationToken" ( which is something that the anonymousAuthenticationFilterChain does