### PR TITLE
[BACKLOG-4460] Added location "null" for the getConfiguration of

### DIFF
--- a/pentaho-server-bundle/src/main/java/org/pentaho/platform/server/osgi/PentahoOSGIActivator.java
+++ b/pentaho-server-bundle/src/main/java/org/pentaho/platform/server/osgi/PentahoOSGIActivator.java
@@ -53,7 +53,7 @@ public class PentahoOSGIActivator implements BundleActivator {
     ConfigurationAdmin configurationAdmin = bundleContext.getService( configurationAdminServiceReference );
 
     // guaranteed to not be null
-    Configuration configuration = configurationAdmin.getConfiguration( "org.pentaho.requirejs" );
+    Configuration configuration = configurationAdmin.getConfiguration( "org.pentaho.requirejs", "null" );
     Dictionary<String, Object> properties = configuration.getProperties();
     if ( properties == null ) {
       // new config

--- a/pentaho-server-bundle/src/test/java/org/pentaho/platform/server/osgi/PentahoOSGIActivatorTest.java
+++ b/pentaho-server-bundle/src/test/java/org/pentaho/platform/server/osgi/PentahoOSGIActivatorTest.java
@@ -46,7 +46,7 @@ public class PentahoOSGIActivatorTest {
     when( bundleContext.getService( adminRef )).thenReturn( configurationAdmin );
 
     Configuration config = mock( Configuration.class );
-    when(configurationAdmin.getConfiguration( "org.pentaho.requirejs" )).thenReturn( config );
+    when(configurationAdmin.getConfiguration( "org.pentaho.requirejs", "null" )).thenReturn( config );
 
     IApplicationContext applicationContext = mock(IApplicationContext.class);
     PentahoSystem.init(applicationContext);


### PR DESCRIPTION
"org.pentaho.requirejs" configuration.
This way, when PentahoOSGIActivator creates the configuration (i.e.,
when there is no configuration with such a name), the location of this
configuration is consistent with the same configuration handled on the
blueprint file of project "pentaho-requirejs-osgi-manager".