### PR TITLE
[BACKLOG-6171] Modified SS2 and SS4 pentaho proxies to be according to

### DIFF
--- a/pentaho-ss2-proxies/src/main/java/org/pentaho/proxy/creators/userdetailsservice/ProxyUserDetailsService.java
+++ b/pentaho-ss2-proxies/src/main/java/org/pentaho/proxy/creators/userdetailsservice/ProxyUserDetailsService.java
@@ -1,3 +1,20 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright 2016 Pentaho Corporation. All rights reserved.
+ */
+
 package org.pentaho.proxy.creators.userdetailsservice;
 
 import org.slf4j.Logger;

--- a/pentaho-ss2-proxies/src/main/java/org/pentaho/proxy/creators/userdetailsservice/ProxyUserDetailsService.java
+++ b/pentaho-ss2-proxies/src/main/java/org/pentaho/proxy/creators/userdetailsservice/ProxyUserDetailsService.java
@@ -1,5 +1,7 @@
 package org.pentaho.proxy.creators.userdetailsservice;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.security.userdetails.UserDetails;
 import org.springframework.security.userdetails.UserDetailsService;
@@ -12,6 +14,10 @@ import java.lang.reflect.Method;
  * Created by tkafalas on 8/24/15.
  */
 public class ProxyUserDetailsService implements UserDetailsService {
+  private Logger logger = LoggerFactory.getLogger( getClass() );
+
+  private String FULL_NAME_SS4_USERNOTFOUNDEXCEPTION = "org.springframework.security.core.userdetails.UsernameNotFoundException";
+
   private Object sourceObject; // Hold the object so it is not garbage collected
   Method loadUserByNameMethod;
   Class<?> loadUserByNameReturnType;
@@ -25,16 +31,22 @@ public class ProxyUserDetailsService implements UserDetailsService {
 
   @Override
   public UserDetails loadUserByUsername( String username ) throws UsernameNotFoundException, DataAccessException {
-    UserDetails proxyUserDetails = null;
     try {
       Object result = ReflectionUtils.invokeMethod( loadUserByNameMethod, sourceObject, new Object[] { username } );
-      proxyUserDetails = new ProxyUserDetails( result );
-      return proxyUserDetails;
+      if ( result != null ) {
+        return new ProxyUserDetails( result );
+      } else {
+        logger.warn( "Got a null from calling the method loadUserByUsername( String username ) of UserDetailsService: "
+            + sourceObject
+            + ". This is an interface violation beacuse it is specified that loadUserByUsername method should never return null. Throwing a UsernameNotFoundException." );
+      }
     } catch ( Exception e ) {
-      if( e.getClass().getName().equals( UsernameNotFoundException.class.getName() ) ){
-        throw new UsernameNotFoundException( username + " not found" );
+      if ( e.getClass().getName().equals( FULL_NAME_SS4_USERNOTFOUNDEXCEPTION ) ) {
+        throw new UsernameNotFoundException( username + " not found", e );
+      } else {
+        logger.error( e.getMessage(), e );
       }
     }
-    return null;
+    throw new UsernameNotFoundException( username );
   }
 }

--- a/pentaho-ss2-proxies/src/test/java/org/pentaho/proxy/creators/userdatailsservice/ProxyUserDetailsServiceTest.java
+++ b/pentaho-ss2-proxies/src/test/java/org/pentaho/proxy/creators/userdatailsservice/ProxyUserDetailsServiceTest.java
@@ -1,29 +1,23 @@
-package org.pentaho.proxy.creators.userdetailsservice;
-
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.pentaho.platform.proxy.api.IProxyFactory;
-import org.pentaho.platform.proxy.api.IProxyRegistration;
-import org.pentaho.platform.proxy.impl.ProxyException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.util.ReflectionUtils;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.List;
-import java.util.Map;
+package org.pentaho.proxy.creators.userdatailsservice;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class S4UserDetailsServiceProxyCreatorTest {
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.proxy.creators.userdetailsservice.ProxyUserDetailsService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.userdetails.UserDetails;
+import org.springframework.security.userdetails.UserDetailsService;
+import org.springframework.security.userdetails.UsernameNotFoundException;
+import org.springframework.util.ReflectionUtils;
 
+public class ProxyUserDetailsServiceTest {
   private Logger logger = LoggerFactory.getLogger( getClass() );
 
   UserDetails mockUserDetails;
@@ -52,7 +46,7 @@ public class S4UserDetailsServiceProxyCreatorTest {
 
   @Test public void testCreateProxyWrapper() {
 
-    Object wrappedObject = new S4UserDetailsServiceProxyCreatorForTest().create( mockUserDetailsService );
+    Object wrappedObject = new ProxyUserDetailsService( mockUserDetailsService );
 
     Assert.assertNotNull( wrappedObject );
 
@@ -89,7 +83,7 @@ public class S4UserDetailsServiceProxyCreatorTest {
 
   @Test public void testNoUserDetailsProxyWrapper() {
 
-    Object wrappedObject = new S4UserDetailsServiceProxyCreatorForTest().create( mockUserDetailsService );
+    Object wrappedObject = new ProxyUserDetailsService( mockUserDetailsService );
 
     Assert.assertNotNull( wrappedObject );
 
@@ -123,27 +117,5 @@ public class S4UserDetailsServiceProxyCreatorTest {
   public void tearDown() {
     mockUserDetails = null;
     mockUserDetailsService = null;
-  }
-
-
-  private class S4UserDetailsServiceProxyCreatorForTest extends S4UserDetailsServiceProxyCreator {
-
-    @Override public boolean supports( Class aClass ) {
-      return true;
-    }
-
-    @Override public IProxyFactory getProxyFactory() {
-      return new IProxyFactory(){
-
-        @Override public <T, K> IProxyRegistration createAndRegisterProxy( T target, List<Class<?>> publishedClasses,
-            Map<String, Object> properties ) throws ProxyException {
-          return null;
-        }
-
-        @Override public <T, K> K createProxy( T target ) throws ProxyException {
-          return ( K ) target;
-        }
-      };
-    }
   }
 }

--- a/pentaho-ss2-proxies/src/test/java/org/pentaho/proxy/creators/userdatailsservice/ProxyUserDetailsServiceTest.java
+++ b/pentaho-ss2-proxies/src/test/java/org/pentaho/proxy/creators/userdatailsservice/ProxyUserDetailsServiceTest.java
@@ -1,3 +1,20 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright 2016 Pentaho Corporation. All rights reserved.
+ */
+
 package org.pentaho.proxy.creators.userdatailsservice;
 
 import static org.mockito.Mockito.mock;

--- a/pentaho-ss4-proxies/src/main/java/org/pentaho/proxy/creators/userdetailsservice/S4UserDetailsServiceProxyCreator.java
+++ b/pentaho-ss4-proxies/src/main/java/org/pentaho/proxy/creators/userdetailsservice/S4UserDetailsServiceProxyCreator.java
@@ -1,3 +1,20 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright 2016 Pentaho Corporation. All rights reserved.
+ */
+
 package org.pentaho.proxy.creators.userdetailsservice;
 
 import org.pentaho.platform.proxy.api.IProxyCreator;

--- a/pentaho-ss4-proxies/src/test/java/org/pentaho/proxy/creators/userdetailsservice/S4UserDetailsServiceProxyCreatorTest.java
+++ b/pentaho-ss4-proxies/src/test/java/org/pentaho/proxy/creators/userdetailsservice/S4UserDetailsServiceProxyCreatorTest.java
@@ -1,3 +1,20 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright 2016 Pentaho Corporation. All rights reserved.
+ */
+
 package org.pentaho.proxy.creators.userdetailsservice;
 
 import org.junit.After;


### PR DESCRIPTION
UserDetailsService interface. When a UserDetails is not found, the
proxies will throw UsernameNotFoundException exception instead of
returning null. Moreover, they will be now expecting
UsernameNotFoundExceptions from the SourceObject, as well as, throwing
UsernameNotFoundException if SourceObject returns null.