### PR TITLE
[BACKLOG-8306] - make properties files be merged with Locale&Priority

### DIFF
--- a/pentaho-i18n-bundle/src/main/java/org/pentaho/osgi/i18n/impl/LocalizationManager.java
+++ b/pentaho-i18n-bundle/src/main/java/org/pentaho/osgi/i18n/impl/LocalizationManager.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -44,7 +43,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -89,11 +87,11 @@ public class LocalizationManager implements LocalizationService {
           URL url = urlEnumeration.nextElement();
           if ( url != null ) {
             String fileName = url.getFile();
-            String relativeName = getPropertyRelativeName( fileName );
+            String relativeName = fileName;
             String name = getPropertyName( fileName );
-            int priority = getPropertyPriority( fileName );
+            int priority = OSGIResourceNamingConvention.getPropertyPriority( fileName );
             bundleFactory = new OSGIResourceBundleFactory( name, relativeName, url, priority );
-            configEntry.put( name, bundleFactory );
+            configEntry.put( relativeName, bundleFactory );
             rebuildCache = true;
           }
         }
@@ -126,21 +124,6 @@ public class LocalizationManager implements LocalizationService {
   }
 
   /**
-   * Returns property's relative name without priority
-   *
-   * @param fileName
-   * @return
-   */
-  private String getPropertyRelativeName( String fileName ) {
-    Matcher matcher = OSGIResourceNamingConvention.getResourceNameMatcher( fileName );
-    String groop = matcher.group( matcher.groupCount() );
-    if ( groop != null ) {
-      fileName = fileName.replace( groop, "" );
-    }
-    return fileName;
-  }
-
-  /**
    * Returns property file name without extension
    *
    * @param fileName
@@ -153,33 +136,20 @@ public class LocalizationManager implements LocalizationService {
       fileName.lastIndexOf( OSGIResourceNamingConvention.RESOURCES_DEFAULT_EXTENSION ) );
   }
 
-  /**
-   * Returns property priority propertyName must have message-name.properties.5 format (priority = 5)
-   *
-   * @param propertyName
-   * @return propertyPriority, default priority = 0
-   */
-  private int getPropertyPriority( String propertyName ) {
-    int priority = 0;
-    Matcher matcher = OSGIResourceNamingConvention.getResourceNameMatcher( propertyName );
-    String groop = matcher.group( matcher.groupCount() );
-    if ( groop != null ) {
-      priority = Integer.parseInt( groop.substring( 1 ) );
-    }
-    return priority;
-  }
-
   @Override
   public ResourceBundle getResourceBundle( String name, Locale locale ) {
     ResourceBundle result = null;
     Map<String, OSGIResourceBundle> localCache = getCache();
 
     if ( localCache != null ) {
-      for ( String candidate : getCandidateNames( name.replaceAll( "\\.", "/" ), locale ) ) {
-        OSGIResourceBundle bundle = localCache.get( candidate );
-        if ( bundle != null ) {
-          result = bundle;
-          break;
+      if ( name != null ) {
+        name = name.replaceAll( "\\.", "/" );
+        for ( String candidate : OSGIResourceNamingConvention.getCandidateNames( name, locale ) ) {
+          OSGIResourceBundle bundle = localCache.get( candidate );
+          if ( bundle != null ) {
+            result = bundle;
+            break;
+          }
         }
       }
     }
@@ -203,7 +173,7 @@ public class LocalizationManager implements LocalizationService {
         }
       }
       for ( String defaultName : defaultNames ) {
-        for ( String candidate : getCandidateNames( defaultName, locale ) ) {
+        for ( String candidate : OSGIResourceNamingConvention.getCandidateNames( defaultName, locale ) ) {
           OSGIResourceBundle bundle = localCache.get( candidate );
           if ( bundle != null ) {
             result.add( bundle );
@@ -214,24 +184,6 @@ public class LocalizationManager implements LocalizationService {
     } else {
       result = null;
     }
-    return result;
-  }
-
-  private List<String> getCandidateNames( String name, Locale locale ) {
-    List<String> result = new ArrayList<String>();
-    String current = name;
-    result.add( current );
-    String language = locale.getLanguage();
-    if ( language.length() > 0 ) {
-      current += "_" + language;
-      result.add( current );
-      String country = locale.getCountry();
-      if ( country.length() > 0 ) {
-        current += "_" + country;
-        result.add( current );
-      }
-    }
-    Collections.reverse( result );
     return result;
   }
 

--- a/pentaho-i18n-bundle/src/main/java/org/pentaho/osgi/i18n/resource/OSGIResourceBundle.java
+++ b/pentaho-i18n-bundle/src/main/java/org/pentaho/osgi/i18n/resource/OSGIResourceBundle.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright 2014 Pentaho Corporation. All rights reserved.
+ * Copyright 2016 Pentaho Corporation. All rights reserved.
  */
 
 package org.pentaho.osgi.i18n.resource;
@@ -27,6 +27,7 @@ import java.util.ResourceBundle;
  */
 public class OSGIResourceBundle extends PropertyResourceBundle {
   private final String defaultName;
+
   public OSGIResourceBundle( String defaultName, URL propertyFileUrl ) throws IOException {
     this( defaultName, null, propertyFileUrl );
   }
@@ -41,5 +42,9 @@ public class OSGIResourceBundle extends PropertyResourceBundle {
 
   public String getDefaultName() {
     return defaultName;
+  }
+
+  public ResourceBundle getParent() {
+    return parent;
   }
 }

--- a/pentaho-i18n-bundle/src/main/java/org/pentaho/osgi/i18n/resource/OSGIResourceBundleCacheCallable.java
+++ b/pentaho-i18n-bundle/src/main/java/org/pentaho/osgi/i18n/resource/OSGIResourceBundleCacheCallable.java
@@ -22,11 +22,19 @@
 
 package org.pentaho.osgi.i18n.resource;
 
+import org.pentaho.osgi.i18n.settings.OSGIResourceNameComparator;
 import org.pentaho.osgi.i18n.settings.OSGIResourceNamingConvention;
 
 import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.concurrent.Callable;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 
 /**
@@ -41,36 +49,74 @@ public class OSGIResourceBundleCacheCallable implements Callable<Map<String, OSG
 
   @Override public Map<String, OSGIResourceBundle> call() throws Exception {
     Map<String, OSGIResourceBundleFactory> factoryMap =
-      new HashMap<String, OSGIResourceBundleFactory>();
+      new TreeMap<>( new OSGIResourceNameComparator() );
     // Select only bundles with highest priority
     for ( Map<String, OSGIResourceBundleFactory> bundleMap : configMap.values() ) {
       for ( Map.Entry<String, OSGIResourceBundleFactory> entry : bundleMap.entrySet() ) {
+        OSGIResourceBundleFactory pathToFactoryMap = entry.getValue();
         String key = entry.getValue().getPropertyFilePath();
-        OSGIResourceBundleFactory pathToFactoryMap = factoryMap.get( key );
-        if ( pathToFactoryMap == null || pathToFactoryMap.getPriority() < entry.getValue().getPriority() ) {
-          pathToFactoryMap = entry.getValue();
-        }
         factoryMap.put( key, pathToFactoryMap );
       }
     }
 
     // Create bundles from factories
     Map<String, OSGIResourceBundle> result = new HashMap<String, OSGIResourceBundle>();
-    for ( Map.Entry<String, OSGIResourceBundleFactory> factoryMapEntry : factoryMap.entrySet() ) {
-      OSGIResourceBundle resultKeyBundles;
-      OSGIResourceBundleFactory nameToFactoryEntry = factoryMapEntry.getValue();
+    Set<String> keys = factoryMap.keySet();
+    SortedMap<String, OSGIResourceBundleFactory> factoryMapCopy =
+      new TreeMap<>( new OSGIResourceNameComparator() );
+    factoryMapCopy.putAll( factoryMap );
+    for ( String key : keys ) {
+      OSGIResourceBundleFactory nameToFactoryEntry = factoryMap.get( key );
       String name = nameToFactoryEntry.getPropertyFilePath();
       Matcher defaultMatcher = OSGIResourceNamingConvention.getResourceNameMatcher( name );
       String defaultName = defaultMatcher.group( 1 );
-      OSGIResourceBundleFactory defaultFactory =
-        factoryMap.get( defaultName + OSGIResourceNamingConvention.RESOURCES_DEFAULT_EXTENSION );
-      OSGIResourceBundle parentBundle = null;
-      if ( defaultFactory != null && defaultFactory != nameToFactoryEntry ) {
-        parentBundle = defaultFactory.getBundle( null );
+      String locale = defaultMatcher.group( 2 );
+      if ( locale.length() > 1 ) {
+        locale = locale.substring( 1 ).replace( '_', '-' );
       }
-      resultKeyBundles = nameToFactoryEntry.getBundle( parentBundle );
+      OSGIResourceBundleFactory defaultFactory = null;
+      List<String> candidates =
+        OSGIResourceNamingConvention.getCandidateNames( defaultName, Locale.forLanguageTag( locale ) );
+      // first try to get closest parent from properties with same locale and then in properties with "lower" locale
+      for ( int i = 0; i < candidates.size(); i++ ) {
+        Optional<String> firstKeyInHierarhy = getFirstKeyInHierarhy( factoryMapCopy, candidates.get( i )
+          + OSGIResourceNamingConvention.RESOURCES_DEFAULT_EXTENSION );
+        //checks that we've found not the same properties as original
+        if ( firstKeyInHierarhy.isPresent()
+          && factoryMapCopy.get( firstKeyInHierarhy.get() ) != nameToFactoryEntry ) {
+          if ( i != candidates.size() - 1 ) {
+            defaultFactory = factoryMapCopy.remove( firstKeyInHierarhy.get() );
+          } else {
+            defaultFactory = factoryMapCopy.get( firstKeyInHierarhy.get() );
+          }
+          break;
+        }
+      }
+      OSGIResourceBundle parentBundle = null;
+      if ( defaultFactory != null ) {
+        parentBundle = result.get( defaultFactory.getBundle( null ).getDefaultName() );
+      }
+      OSGIResourceBundle resultKeyBundles = nameToFactoryEntry.getBundle( parentBundle );
       result.put( resultKeyBundles.getDefaultName(), resultKeyBundles );
     }
     return result;
+  }
+
+  /**
+   * Gets first key from SortedMap with starts with parameter name
+   *
+   * @param factoryMapWithoutCurrent map to search from
+   * @param name                     starting string
+   * @return key
+   */
+  private Optional<String> getFirstKeyInHierarhy( SortedMap<String, OSGIResourceBundleFactory> factoryMapWithoutCurrent,
+                                                  String name ) {
+    return factoryMapWithoutCurrent.keySet().stream()
+      .filter( new Predicate<String>() {
+        @Override public boolean test( String s ) {
+          return s.startsWith( name );
+        }
+      } )
+      .findFirst();
   }
 }

--- a/pentaho-i18n-bundle/src/main/java/org/pentaho/osgi/i18n/settings/OSGIResourceNameComparator.java
+++ b/pentaho-i18n-bundle/src/main/java/org/pentaho/osgi/i18n/settings/OSGIResourceNameComparator.java
@@ -1,0 +1,40 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright 2016 Pentaho Corporation. All rights reserved.
+ */
+
+package org.pentaho.osgi.i18n.settings;
+
+import java.util.Comparator;
+import java.util.regex.Matcher;
+
+/**
+ * Created by Viktoryia_Klimenka on 6/7/2016.
+ */
+public class OSGIResourceNameComparator implements Comparator<String> {
+  @Override public int compare( String o1, String o2 ) {
+    Matcher o1Matcher = OSGIResourceNamingConvention.getResourceNameMatcher( o1 );
+    Matcher o2Matcher = OSGIResourceNamingConvention.getResourceNameMatcher( o2 );
+    String name1 = o1Matcher.group( 1 ) + o1Matcher.group( 2 );
+    String name2 = o2Matcher.group( 1 ) + o2Matcher.group( 2 );
+    if ( name1.compareTo( name2 ) == 0 ) {
+      int priority1 = OSGIResourceNamingConvention.getPropertyPriority( o1 );
+      int priority2 = OSGIResourceNamingConvention.getPropertyPriority( o2 );
+      return priority1 - priority2;
+    } else {
+      return name1.compareTo( name2 );
+    }
+  }
+}

--- a/pentaho-i18n-bundle/src/main/java/org/pentaho/osgi/i18n/settings/OSGIResourceNamingConvention.java
+++ b/pentaho-i18n-bundle/src/main/java/org/pentaho/osgi/i18n/settings/OSGIResourceNamingConvention.java
@@ -17,6 +17,10 @@
 
 package org.pentaho.osgi.i18n.settings;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -39,5 +43,39 @@ public class OSGIResourceNamingConvention {
       throw new IllegalArgumentException(
         "Path must be of the form prefix/filename[_internationalization].properties[.priority]" );
     }
+  }
+
+  /**
+   * Returns property priority propertyName must have message-name.properties.5 format (priority = 5)
+   *
+   * @param propertyName i18n resource name
+   * @return propertyPriority, default priority = 0
+   */
+  public static int getPropertyPriority( String propertyName ) {
+    int priority = 0;
+    Matcher matcher = getResourceNameMatcher( propertyName );
+    String groop = matcher.group( matcher.groupCount() );
+    if ( groop != null ) {
+      priority = Integer.parseInt( groop.substring( 1 ) );
+    }
+    return priority;
+  }
+
+  public static List<String> getCandidateNames( String name, Locale locale ) {
+    List<String> result = new ArrayList<String>();
+    String current = name;
+    result.add( current );
+    String language = locale.getLanguage();
+    if ( language.length() > 0 ) {
+      current += "_" + language;
+      result.add( current );
+      String country = locale.getCountry();
+      if ( country.length() > 0 ) {
+        current += "_" + country;
+        result.add( current );
+      }
+    }
+    Collections.reverse( result );
+    return result;
   }
 }

--- a/pentaho-i18n-bundle/src/test/java/org/pentaho/osgi/i18n/impl/LocalizationManagerTest.java
+++ b/pentaho-i18n-bundle/src/test/java/org/pentaho/osgi/i18n/impl/LocalizationManagerTest.java
@@ -26,7 +26,9 @@ import org.json.simple.parser.ParseException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Matchers;
 import org.osgi.framework.Bundle;
+import org.pentaho.osgi.i18n.resource.OSGIResourceBundle;
 import org.slf4j.Logger;
 
 import java.io.IOException;
@@ -34,8 +36,12 @@ import java.net.URL;
 import java.util.Locale;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.Vector;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
@@ -73,7 +79,7 @@ public class LocalizationManagerTest {
     assertBundleNullCacheNullRegexp( Pattern.compile( "messages" ),
       "de", "DE" );
 
-    localizationManager.bundleChanged(makeMockBundleNull( 1L) );
+    localizationManager.bundleChanged( makeMockBundleNull( 1L, Bundle.ACTIVE ) );
     assertBundleNullCacheNull( "messages", "de", "DE" );
     assertBundleNullCacheNull( null, "de", "DE" );
     assertBundleNullCacheNull( "messages", null );
@@ -82,8 +88,10 @@ public class LocalizationManagerTest {
     assertBundleNullCacheNull( "messages", "de", "DE" );
     assertBundleNullCacheNull( null, "de", "DE" );
     assertBundleNullCacheNull( "messages", null );
-    localizationManager.bundleChanged(makeMockBundle( 1L, Bundle.ACTIVE, "i18n/bundle/messages.properties",
-        "i18n/bundle/messages_fr.properties", "i18n/bundle/messages_de_DE.properties" ) );
+    localizationManager.bundleChanged( makeMockBundle( 1L, Bundle.ACTIVE, "i18n/bundle/messages.properties",
+      "i18n/bundle/messages_fr.properties", "i18n/bundle/messages_de_DE.properties" ) );
+    assertBundleNullCacheNull( null, "de", "DE" );
+    assertBundleNullCacheNull( "", "de", "DE" );
     assertBundleKeyEquals( "defaultKey", "bundle/messages", "defaultKey", "fakeLocale" );
     assertBundleKeyEquals( "key", "bundle/messages", "key", "fakeLocale" );
     assertBundleKeyEquals( "key_fr", "bundle/messages", "key", "fr" );
@@ -109,9 +117,11 @@ public class LocalizationManagerTest {
     localizationManager.bundleChanged( makeMockBundle( 2L, Bundle.ACTIVE, "i18n/bundle/messages_fr.properties.2" ) );
     assertBundleKeyEquals( "key_fr_bundle2", "bundle/messages", "key", "fr" );
     assertBundleKeyEquals( "defaultKey", "bundle/messages", "defaultKey", "fr" );
+    assertBundleKeyEquals( "key for priority 2", "bundle/messages", "key2", "fr" );
 
     assertBundlePatternKeyEquals( "key_fr_bundle2", Pattern.compile( ".*messages" ), "key", "fr" );
     assertBundlePatternKeyEquals( "defaultKey", Pattern.compile( ".*messages" ), "defaultKey", "fr" );
+    assertBundlePatternKeyEquals( "key for priority 2", Pattern.compile( ".*messages" ), "key2", "fr" );
 
     //test bundle 2L stopping
     localizationManager.bundleChanged( makeMockBundle( 2L, Bundle.RESOLVED, "i18n/bundle/messages_fr.properties.2" ) );
@@ -123,16 +133,27 @@ public class LocalizationManagerTest {
     localizationManager.bundleChanged( makeMockBundle( 3L, Bundle.ACTIVE, "i18n/bundle/messages_fr.properties.3" ) );
     assertBundleKeyEquals( "key_fr_bundle3", "bundle/messages", "key", "fr" );
     assertBundleKeyEquals( "defaultKey", "bundle/messages", "defaultKey", "fr" );
+    assertBundleKeyEquals( "key for priority 3", "bundle/messages", "key3", "fr" );
 
     assertBundlePatternKeyEquals( "key_fr_bundle3", Pattern.compile( ".*messages" ), "key", "fr" );
     assertBundlePatternKeyEquals( "defaultKey", Pattern.compile( ".*messages" ), "defaultKey", "fr" );
+    assertBundlePatternKeyEquals( "key for priority 3", Pattern.compile( ".*messages" ), "key3", "fr" );
 
-    localizationManager.bundleChanged( makeMockBundle( 4L, Bundle.ACTIVE, "fakepath" ) );
+    localizationManager.bundleChanged( makeMockBundle( 4L, Bundle.ACTIVE, "i18n/bundle/messages_fr.properties.4" ) );
+    assertBundleKeyEquals( "key_fr_bundle4", "bundle/messages", "key", "fr" );
+    assertBundleKeyEquals( "defaultKey", "bundle/messages", "defaultKey", "fr" );
+    assertBundleKeyEquals( "key for priority 3", "bundle/messages", "key3", "fr" );
+
+    assertBundlePatternKeyEquals( "key_fr_bundle4", Pattern.compile( ".*messages" ), "key", "fr" );
+    assertBundlePatternKeyEquals( "defaultKey", Pattern.compile( ".*messages" ), "defaultKey", "fr" );
+    assertBundlePatternKeyEquals( "key for priority 3", Pattern.compile( ".*messages" ), "key3", "fr" );
+
+    localizationManager.bundleChanged( makeMockBundle( 5L, Bundle.ACTIVE, "fakepath" ) );
     assertBundleKeyEquals( "defaultKey", "bundle/messages", "defaultKey", "fakeLocale" );
     assertBundleKeyEquals( "key", "bundle/messages", "key", "fakeLocale" );
-    assertBundleKeyEquals( "key_fr_bundle3", "bundle/messages", "key", "fr" );
+    assertBundleKeyEquals( "key_fr_bundle4", "bundle/messages", "key", "fr" );
     assertBundleKeyEquals( "defaultKey", "bundle/messages", "defaultKey", "fr" );
-    assertBundleKeyEquals( "key_fr_bundle3", "bundle/messages", "key", "fr", "FR" );
+    assertBundleKeyEquals( "key_fr_bundle4", "bundle/messages", "key", "fr", "FR" );
     assertBundleKeyEquals( "defaultKey", "bundle/messages", "defaultKey", "fr", "FR" );
     assertBundleKeyEquals( "key", "bundle/messages", "key", "de" );
     assertBundleKeyEquals( "defaultKey", "bundle/messages", "defaultKey", "de" );
@@ -141,15 +162,31 @@ public class LocalizationManagerTest {
 
     assertBundlePatternKeyEquals( "defaultKey", Pattern.compile( ".*messages" ), "defaultKey", "fakeLocale" );
     assertBundlePatternKeyEquals( "key", Pattern.compile( ".*messages" ), "key", "fakeLocale" );
-    assertBundlePatternKeyEquals( "key_fr_bundle3", Pattern.compile( ".*messages" ), "key", "fr" );
+    assertBundlePatternKeyEquals( "key_fr_bundle4", Pattern.compile( ".*messages" ), "key", "fr" );
     assertBundlePatternKeyEquals( "defaultKey", Pattern.compile( ".*messages" ), "defaultKey", "fr" );
-    assertBundlePatternKeyEquals( "key_fr_bundle3", Pattern.compile( ".*messages" ), "key", "fr", "FR" );
+    assertBundlePatternKeyEquals( "key_fr_bundle4", Pattern.compile( ".*messages" ), "key", "fr", "FR" );
     assertBundlePatternKeyEquals( "defaultKey", Pattern.compile( ".*messages" ), "defaultKey", "fr", "FR" );
     assertBundlePatternKeyEquals( "key", Pattern.compile( ".*messages" ), "key", "de" );
     assertBundlePatternKeyEquals( "defaultKey", Pattern.compile( ".*messages" ), "defaultKey", "de" );
     assertBundlePatternKeyEquals( "key_de_DE", Pattern.compile( ".*messages" ), "key", "de", "DE" );
     assertBundlePatternKeyEquals( "defaultKey", Pattern.compile( ".*messages" ), "defaultKey", "de", "DE" );
-    assertBundlePatternKeyEquals( "defaultKey", Pattern.compile( ".*messages" ), "defaultKey", "");
+    assertBundlePatternKeyEquals( "defaultKey", Pattern.compile( ".*messages" ), "defaultKey", "" );
+  }
+
+  @Test
+  public void testLocalosationManagerWrongCache()
+    throws IOException, ParseException, ExecutionException, InterruptedException {
+    localizationManager.setExecutorService( mockExecutorServiceWithCacheTrowingError() );
+    localizationManager.bundleChanged( makeMockBundle( 2L, Bundle.ACTIVE, "i18n/bundle/messages_fr.properties.2" ) );
+    assertBundleNullCacheNull("bundle/messages", "key", "fr" );
+  }
+
+  private ExecutorService mockExecutorServiceWithCacheTrowingError() throws ExecutionException, InterruptedException {
+    Future<Map<String, OSGIResourceBundle>> mockF = mock( Future.class );
+    when( mockF.get() ).thenThrow( InterruptedException.class );
+    ExecutorService service = mock( ExecutorService.class );
+    when( service.submit( Matchers.any( Callable.class ) ) ).thenReturn( mockF );
+    return service;
   }
 
   private void assertBundleKeyEquals( String expected, String key, String valueKey,
@@ -224,10 +261,11 @@ public class LocalizationManagerTest {
     return bundle;
   }
 
-  private Bundle makeMockBundleNull( Long bundleId ) {
-      Bundle bundle = mock( Bundle.class );
-      when( bundle.getBundleId() ).thenReturn( bundleId );
-      when( bundle.findEntries( "i18n", "*.properties*", true)).thenReturn( null );
-      return bundle;
+  private Bundle makeMockBundleNull( Long bundleId, int bundleStatus ) {
+    Bundle bundle = mock( Bundle.class );
+    when( bundle.getState() ).thenReturn( bundleStatus );
+    when( bundle.getBundleId() ).thenReturn( bundleId );
+    when( bundle.findEntries( "i18n", "*.properties*", true ) ).thenReturn( null );
+    return bundle;
   }
 }

--- a/pentaho-i18n-bundle/src/test/java/org/pentaho/osgi/i18n/resource/OSGIResourceBundleCacheCallableTest.java
+++ b/pentaho-i18n-bundle/src/test/java/org/pentaho/osgi/i18n/resource/OSGIResourceBundleCacheCallableTest.java
@@ -23,13 +23,12 @@
 package org.pentaho.osgi.i18n.resource;
 
 import org.junit.Test;
+import org.pentaho.osgi.i18n.settings.OSGIResourceNameComparator;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
+import java.util.TreeMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -48,23 +47,26 @@ public class OSGIResourceBundleCacheCallableTest {
       new HashMap<Long, Map<String, OSGIResourceBundleFactory>>();
     String key = "bundle/messages";
     String frenchSuffix = "_fr_FR";
-    Map<String, OSGIResourceBundleFactory> bundle1Map = new HashMap<String, OSGIResourceBundleFactory>();
+    Map<String, OSGIResourceBundleFactory> bundle1Map =
+      new TreeMap<String, OSGIResourceBundleFactory>( new OSGIResourceNameComparator() );
     configMap.put( 1L, bundle1Map );
     OSGIResourceBundleFactory defaultFactory = mock( OSGIResourceBundleFactory.class );
     OSGIResourceBundle defaultBundle = mock( OSGIResourceBundle.class );
     when( defaultBundle.getDefaultName() ).thenReturn( key );
-    bundle1Map.put( key, defaultFactory );
     when( defaultFactory.getBundle( any( ResourceBundle.class ) ) ).thenReturn( defaultBundle );
     when( defaultFactory.getPropertyFilePath() ).thenReturn( key + ".properties" );
+    bundle1Map.put( defaultFactory.getPropertyFilePath(), defaultFactory );
 
-    Map<String, OSGIResourceBundleFactory> bundle2Map = new HashMap<String, OSGIResourceBundleFactory>();
+    Map<String, OSGIResourceBundleFactory> bundle2Map =
+      new TreeMap<String, OSGIResourceBundleFactory>( new OSGIResourceNameComparator() );
     configMap.put( 2L, bundle2Map );
     OSGIResourceBundleFactory frenchFactory = mock( OSGIResourceBundleFactory.class );
     OSGIResourceBundle frenchBundle = mock( OSGIResourceBundle.class );
     when( frenchBundle.getDefaultName() ).thenReturn( key + frenchSuffix);
-    bundle2Map.put( key, frenchFactory );
+    when( frenchBundle.getParent() ).thenReturn( defaultBundle );
     when( frenchFactory.getBundle( any( ResourceBundle.class ) ) ).thenReturn( frenchBundle );
     when( frenchFactory.getPropertyFilePath() ).thenReturn( key + frenchSuffix + ".properties" );
+    bundle2Map.put( frenchFactory.getPropertyFilePath(), frenchFactory );
 
     OSGIResourceBundleCacheCallable osgiResourceBundleCacheCallable = new OSGIResourceBundleCacheCallable( configMap );
     Map<String, OSGIResourceBundle> result = osgiResourceBundleCacheCallable.call();
@@ -85,57 +87,65 @@ public class OSGIResourceBundleCacheCallableTest {
       new HashMap<Long, Map<String, OSGIResourceBundleFactory>>();
     String key = "bundle/messages";
     String frenchSuffix = "_fr_FR";
-    Map<String, OSGIResourceBundleFactory> bundle1Map = new HashMap<String, OSGIResourceBundleFactory>();
+    Map<String, OSGIResourceBundleFactory> bundle1Map =
+      new TreeMap<String, OSGIResourceBundleFactory>( new OSGIResourceNameComparator() );
     configMap.put( 1L, bundle1Map );
     OSGIResourceBundleFactory defaultFactory = mock( OSGIResourceBundleFactory.class );
     OSGIResourceBundle defaultBundle = mock( OSGIResourceBundle.class );
     when( defaultBundle.getDefaultName() ).thenReturn( key );
-    bundle1Map.put( key, defaultFactory );
+    when( defaultFactory.getBundle( any( ResourceBundle.class ) ) ).thenReturn( defaultBundle );
     when( defaultFactory.getBundle( any( ResourceBundle.class ) ) ).thenReturn( defaultBundle );
     when( defaultFactory.getPropertyFilePath() ).thenReturn( key + ".properties" );
+    bundle1Map.put( defaultFactory.getPropertyFilePath() , defaultFactory );
 
-    Map<String, OSGIResourceBundleFactory> bundle2Map = new HashMap<String, OSGIResourceBundleFactory>();
+    Map<String, OSGIResourceBundleFactory> bundle2Map =
+      new TreeMap<String, OSGIResourceBundleFactory>( new OSGIResourceNameComparator() );
     configMap.put( 2L, bundle2Map );
     OSGIResourceBundleFactory frenchFactory = mock( OSGIResourceBundleFactory.class );
     OSGIResourceBundle frenchBundle = mock( OSGIResourceBundle.class );
     when( frenchBundle.getDefaultName() ).thenReturn( key + frenchSuffix);
-    bundle2Map.put( key, frenchFactory );
+    when( frenchBundle.getParent() ).thenReturn( defaultBundle );
     when( frenchFactory.getBundle( any( ResourceBundle.class ) ) ).thenReturn( frenchBundle );
-    when( frenchFactory.getPropertyFilePath() ).thenReturn( key + frenchSuffix + ".properties" );
-    when( frenchFactory.getPriority() ).thenReturn( 5 );
+    when( frenchFactory.getPropertyFilePath() ).thenReturn( key + frenchSuffix + ".properties.5" );
+    when( frenchFactory.getPriority() ).thenReturn( new Integer( 5 ) );
+    bundle2Map.put( frenchFactory.getPropertyFilePath(), frenchFactory );
 
-    Map<String, OSGIResourceBundleFactory> bundle3Map = new HashMap<String, OSGIResourceBundleFactory>();
-    configMap.put( 3L, bundle3Map );
+    Map<String, OSGIResourceBundleFactory> bundle3Map =
+      new TreeMap<String, OSGIResourceBundleFactory>( new OSGIResourceNameComparator() );
+    configMap.put( 4L, bundle3Map );
     OSGIResourceBundleFactory frenchFactory2 = mock( OSGIResourceBundleFactory.class );
     OSGIResourceBundle frenchBundle2 = mock( OSGIResourceBundle.class );
     when( frenchBundle2.getDefaultName() ).thenReturn( key + frenchSuffix);
-    bundle3Map.put( key, frenchFactory2 );
+    when( frenchBundle2.getParent() ).thenReturn( frenchBundle );
     when( frenchFactory2.getBundle( any( ResourceBundle.class ) ) ).thenReturn( frenchBundle2 );
-    when( frenchFactory2.getPropertyFilePath() ).thenReturn( key + frenchSuffix + ".properties" );
-    when( frenchFactory2.getPriority() ).thenReturn( 11 );
+    when( frenchFactory2.getPropertyFilePath() ).thenReturn( key + frenchSuffix + ".properties.8" );
+    when( frenchFactory2.getPriority() ).thenReturn( new Integer( 8 ) );
+    bundle3Map.put( frenchFactory2.getPropertyFilePath(), frenchFactory2 );
 
-    Map<String, OSGIResourceBundleFactory> bundle4Map = new HashMap<String, OSGIResourceBundleFactory>();
-    configMap.put( 4L, bundle4Map );
+    Map<String, OSGIResourceBundleFactory> bundle4Map =
+      new TreeMap<String, OSGIResourceBundleFactory>( new OSGIResourceNameComparator() );
+    configMap.put( 3L, bundle4Map );
     OSGIResourceBundleFactory frenchFactory3 = mock( OSGIResourceBundleFactory.class );
     OSGIResourceBundle frenchBundle3 = mock( OSGIResourceBundle.class );
     when( frenchBundle3.getDefaultName() ).thenReturn( key + frenchSuffix);
-    bundle4Map.put( key, frenchFactory3 );
+    when( frenchBundle3.getParent() ).thenReturn( frenchBundle2 );
     when( frenchFactory3.getBundle( any( ResourceBundle.class ) ) ).thenReturn( frenchBundle3 );
-    when( frenchFactory3.getPropertyFilePath() ).thenReturn( key + frenchSuffix + ".properties" );
-    when( frenchFactory3.getPriority() ).thenReturn( 8 );
+    when( frenchFactory3.getPropertyFilePath() ).thenReturn( key + frenchSuffix + ".properties.11" );
+    when( frenchFactory3.getPriority() ).thenReturn( new Integer( 11 ) );
+    bundle4Map.put( frenchFactory3.getPropertyFilePath(), frenchFactory3 );
 
     OSGIResourceBundleCacheCallable osgiResourceBundleCacheCallable = new OSGIResourceBundleCacheCallable( configMap );
     Map<String, OSGIResourceBundle> result = osgiResourceBundleCacheCallable.call();
-    verify( frenchFactory2 ).getBundle( defaultBundle );
-    verify( frenchFactory, never() ).getBundle( any( ResourceBundle.class ) );
-    verify( frenchFactory3, never() ).getBundle( any( ResourceBundle.class ) );
+    verify( frenchFactory3 ).getBundle( frenchBundle2 );
+    verify( frenchFactory2 ).getBundle( frenchBundle );
+    verify( frenchFactory ).getBundle( defaultBundle );
     assertEquals( 2, result.size() );
     OSGIResourceBundle bundle = result.get( key );
     assertNotNull( bundle );
     assertEquals( defaultBundle, bundle );
     OSGIResourceBundle bundleFr = result.get( key + frenchSuffix );
     assertNotNull( bundleFr );
-    assertEquals( frenchBundle2, bundleFr );
+    assertEquals( frenchBundle3, bundleFr );
   }
 
   @Test
@@ -145,14 +155,14 @@ public class OSGIResourceBundleCacheCallableTest {
     String key = "bundle/messages";
     String frenchSuffix = "_fr_FR";
 
-    Map<String, OSGIResourceBundleFactory> bundle2Map = new HashMap<String, OSGIResourceBundleFactory>();
+    Map<String, OSGIResourceBundleFactory> bundle2Map = new TreeMap<String, OSGIResourceBundleFactory>();
     configMap.put( 2L, bundle2Map );
     OSGIResourceBundleFactory frenchFactory = mock( OSGIResourceBundleFactory.class );
     OSGIResourceBundle frenchBundle = mock( OSGIResourceBundle.class );
     when( frenchBundle.getDefaultName() ).thenReturn( key );
-    bundle2Map.put( key, frenchFactory );
     when( frenchFactory.getBundle( any( ResourceBundle.class ) ) ).thenReturn( frenchBundle );
     when( frenchFactory.getPropertyFilePath() ).thenReturn( key + frenchSuffix + ".properties" );
+    bundle2Map.put( frenchFactory.getPropertyFilePath(), frenchFactory );
 
     OSGIResourceBundleCacheCallable osgiResourceBundleCacheCallable = new OSGIResourceBundleCacheCallable( configMap );
     Map<String, OSGIResourceBundle> result = osgiResourceBundleCacheCallable.call();
@@ -168,13 +178,13 @@ public class OSGIResourceBundleCacheCallableTest {
     Map<Long, Map<String, OSGIResourceBundleFactory>> configMap =
       new HashMap<Long, Map<String, OSGIResourceBundleFactory>>();
     String key = "test-plugin";
-    Map<String, OSGIResourceBundleFactory> bundle1Map = new HashMap<String, OSGIResourceBundleFactory>();
+    Map<String, OSGIResourceBundleFactory> bundle1Map = new TreeMap<String, OSGIResourceBundleFactory>();
     configMap.put( 1L, bundle1Map );
     OSGIResourceBundleFactory defaultFactory = mock( OSGIResourceBundleFactory.class );
     OSGIResourceBundle defaultBundle = mock( OSGIResourceBundle.class );
-    bundle1Map.put( key, defaultFactory );
     when( defaultFactory.getBundle( any( ResourceBundle.class ) ) ).thenReturn( defaultBundle );
     when( defaultFactory.getPropertyFilePath() ).thenReturn( key + ".properties" );
+    bundle1Map.put( defaultFactory.getPropertyFilePath(), defaultFactory );
 
     OSGIResourceBundleCacheCallable osgiResourceBundleCacheCallable = new OSGIResourceBundleCacheCallable( configMap );
     osgiResourceBundleCacheCallable.call();

--- a/pentaho-i18n-bundle/src/test/java/org/pentaho/osgi/i18n/resource/OSGIResourceBundleTest.java
+++ b/pentaho-i18n-bundle/src/test/java/org/pentaho/osgi/i18n/resource/OSGIResourceBundleTest.java
@@ -46,6 +46,7 @@ public class OSGIResourceBundleTest {
     String childPath = "i18n/resource/OSGIResourceBundleTestChild.properties";
     OSGIResourceBundle osgiResourceBundleChild = new OSGIResourceBundle( childPath, osgiResourceBundle,
       getClass().getClassLoader().getResource( childPath ) );
+    assertEquals( osgiResourceBundle, osgiResourceBundleChild.getParent() );
     assertEquals( "testValueChild", osgiResourceBundleChild.getString( "key" ) );
     assertEquals( "testValueParent", osgiResourceBundleChild.getString( "parentKey" ) );
   }

--- a/pentaho-i18n-bundle/src/test/java/org/pentaho/osgi/i18n/settings/OSGIResourceNameComparatorTest.java
+++ b/pentaho-i18n-bundle/src/test/java/org/pentaho/osgi/i18n/settings/OSGIResourceNameComparatorTest.java
@@ -1,0 +1,70 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright 2016 Pentaho Corporation. All rights reserved.
+ */
+
+package org.pentaho.osgi.i18n.settings;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Created by Viktoryia_Klimenka on 6/7/2016.
+ */
+public class OSGIResourceNameComparatorTest {
+  OSGIResourceNameComparator comparator;
+
+  @Before
+  public void setup() {
+    comparator = new OSGIResourceNameComparator();
+  }
+
+  @Test( expected = NullPointerException.class )
+  public void testNullName() {
+    String first = null;
+    String second = "bundle/messages.properties";
+    comparator.compare( first, second );
+  }
+
+  @Test( expected = IllegalArgumentException.class )
+  public void testEmptyName() {
+    String first = "";
+    String second = "bundle/messages.properties";
+    comparator.compare( first, second );
+  }
+
+  @Test
+  public void testNoPriority() {
+    String first = "bundle/messages_en.properties";
+    String second = "bundle/messages.properties";
+    Assert.assertTrue( comparator.compare( first, second ) > 0 );
+  }
+
+  @Test
+  public void testWithPriority() {
+    String first = "bundle/messages.properties.3";
+    String second = "bundle/messages.properties.2";
+    Assert.assertTrue( comparator.compare( first, second ) > 0 );
+  }
+
+  @Test
+  public void testMixed() {
+    String first = "bundle/messages.properties.2";
+    String second = "bundle/messages.properties";
+    Assert.assertTrue( comparator.compare( first, second ) > 0 );
+  }
+
+}

--- a/pentaho-i18n-bundle/src/test/java/org/pentaho/osgi/i18n/settings/OSGIResourceNamingConventionTest.java
+++ b/pentaho-i18n-bundle/src/test/java/org/pentaho/osgi/i18n/settings/OSGIResourceNamingConventionTest.java
@@ -36,7 +36,7 @@ public class OSGIResourceNamingConventionTest {
   @Test( expected = IllegalArgumentException.class )
   public void testEmptyName() {
     String name = "";
-    OSGIResourceNamingConvention.getResourceNameMatcher( name );
+    new OSGIResourceNamingConvention().getResourceNameMatcher( name );
   }
 
   @Test

--- a/pentaho-i18n-bundle/src/test/resources/i18n/bundle/messages_fr.properties.2
+++ b/pentaho-i18n-bundle/src/test/resources/i18n/bundle/messages_fr.properties.2
@@ -1,1 +1,2 @@
 key=key_fr_bundle2
+key2=key for priority 2

--- a/pentaho-i18n-bundle/src/test/resources/i18n/bundle/messages_fr.properties.3
+++ b/pentaho-i18n-bundle/src/test/resources/i18n/bundle/messages_fr.properties.3
@@ -1,1 +1,2 @@
 key=key_fr_bundle3
+key3=key for priority 3

--- a/pentaho-i18n-bundle/src/test/resources/i18n/bundle/messages_fr.properties.4
+++ b/pentaho-i18n-bundle/src/test/resources/i18n/bundle/messages_fr.properties.4
@@ -1,0 +1,2 @@
+key=key_fr_bundle4
+key4=key for priority 4


### PR DESCRIPTION
Hierarchy of properties files is build according to their Locale and Priority.
Hierarchy starts with more detailed Locale and higher priority, so if we have following files, their hierarchy would be:

messages_en_US.properties
messages_en.properties.3
messages_en.properties
messages.properties.4
messages.properties.2
messages.properties Key is searched in properties starting with Locale you've asked and down. First key occurrence is used.