### PR TITLE
[PDI-14698] Blueprint Watcher investigating bundles in Resolved state…

### DIFF
--- a/pentaho-osgi-utils-impl/src/main/java/org/pentaho/osgi/impl/KarafBlueprintWatcherImpl.java
+++ b/pentaho-osgi-utils-impl/src/main/java/org/pentaho/osgi/impl/KarafBlueprintWatcherImpl.java
@@ -76,6 +76,16 @@ public class KarafBlueprintWatcherImpl implements IKarafBlueprintWatcher {
         while ( true ) {
           List<String> unloadedBlueprints = new ArrayList<String>();
           for ( Bundle bundle : bundleContext.getBundles() ) {
+            if( bundle.getState() != Bundle.RESOLVED ){
+              // We're only interested in bundles which are resolved, not started or installed. This is because a
+              // bundle which should have started but failed will be in the resolved state.
+              // We cannot assume an installed bundle is meant to be started and thus wait for it, bundles can be
+              // installed and never started (even though with Karaf this would be very strange). The only thing we can
+              // reasonably do here is skip non-resolved bundles.
+              logger.debug( "Blueprint check was skipped for bundle {} as it's not in the 'Resolved' state",
+                  bundle.getSymbolicName() );
+              continue;
+            }
             if ( blueprintStateService.hasBlueprint( bundle.getBundleId() ) ) {
               if ( !blueprintStateService.isBlueprintLoaded( bundle.getBundleId() ) ) {
                 unloadedAndFailedBlueprints.add( bundle );


### PR DESCRIPTION
… can cause their resolution while resolution is already in progress on a separate thread. This results in cycling those bundles from Resolved back to Installed which can trigger failures down the line.

 This change makes the watcher skip over bundles in Resolved state to avoid this problem. Unfortunately OSGI does not provide a "Resolving" status