### PR TITLE
[BACKLOG-9079] - Removed Table Viz from lowdeps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,6 @@
         <module>pentaho-capability-manager</module>
         <module>pentaho-cache-manager</module>
         <module>pentaho-authentication-mapper</module>
-        <module>pentaho-flat-table-viz</module>
       </modules>
       <distributionManagement>
         <site>


### PR DESCRIPTION
This broke the QAT Build