### PR TITLE
[BACKLOG-9894] DET: In Firefox - DET does not open ( only outside PDI )

### DIFF
--- a/pentaho-i18n-webservice-bundle/src/main/javascript/web/js/i18n.js
+++ b/pentaho-i18n-webservice-bundle/src/main/javascript/web/js/i18n.js
@@ -32,8 +32,13 @@
         var baseUrl = CONTEXT_PATH && CONTEXT_PATH == '/' ? CONTEXT_PATH : CONTEXT_PATH + "osgi/";
         var locale = typeof SESSION_LOCALE !== "undefined" ? SESSION_LOCALE : "en";
         var url = baseUrl + "cxf/i18n/" + bundlePath + "/" + locale;
+        var options = {
+          "headers": {
+            "Accept": "application/JSON"
+          }
+        };
         
-        request(url).then(function (data) {
+        request(url, options).then(function (data) {
           if (data) {
             var bundle = new MessageBundle(JSON.parse(data));
             onLoad(bundle);


### PR DESCRIPTION
In the accept header of Firefox we don't have **"application/JSON"**, which is what **pentaho-i18n-webservice-bundle** is expecting. This wasn't happening in Chrome because the **accept header** set to accept anything.

@diogofscmariano @pentaho/kashyyyk please review