### PR TITLE
[PPP-3559] Update version of vulnerable component Angular.js 1.2.21

### DIFF
--- a/pentaho-notification-webservice-bundle/pom.xml
+++ b/pentaho-notification-webservice-bundle/pom.xml
@@ -78,7 +78,14 @@
     <dependency>
       <groupId>org.webjars</groupId>
       <artifactId>angularjs</artifactId>
-      <version>1.2.21</version>
+      <version>1.5.8</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>pentaho</groupId>
+      <artifactId>common-ui</artifactId>
+      <version>${project.version}</version>
+      <type>zip</type>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -94,7 +101,7 @@
       <plugin>
         <groupId>com.github.searls</groupId>
         <artifactId>jasmine-maven-plugin</artifactId>
-        <version>1.3.1.5</version>
+        <version>2.2</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
@pamval @YuryBY please review. Adding `common-ui` as a test dependency and updating the version of the `jasmine-maven-plugin` test dependency allows the project `pentaho-notification-webservice-bundle` to build successfully after updating `angularjs` to version 1.5.8.