### PR TITLE
[BACKLOG-11614] Karaf temporary folders are not deleted in case of

### DIFF
--- a/pentaho-osgi-utils-impl/src/main/java/org/pentaho/osgi/impl/KarafBlueprintWatcherImpl.java
+++ b/pentaho-osgi-utils-impl/src/main/java/org/pentaho/osgi/impl/KarafBlueprintWatcherImpl.java
@@ -124,6 +124,7 @@ public class KarafBlueprintWatcherImpl implements IKarafBlueprintWatcher {
           logger.debug( System.lineSeparator() + getBlueprintsReport( blueprintStateService,
             unloadedAndFailedBlueprints ) );
         }
+        serviceTracker.close();
       }
     }
   }

--- a/pentaho-osgi-utils-impl/src/main/java/org/pentaho/osgi/impl/KarafFeatureWatcherImpl.java
+++ b/pentaho-osgi-utils-impl/src/main/java/org/pentaho/osgi/impl/KarafFeatureWatcherImpl.java
@@ -119,11 +119,12 @@ public class KarafFeatureWatcherImpl implements IKarafFeatureWatcher {
 
         waitForFeatures( extraFeatures, featuresService );
 
-
       } catch ( IOException e ) {
         throw new FeatureWatcherException( "Error accessing ConfigurationAdmin", e );
       } catch ( Exception e ) {
         throw new FeatureWatcherException( "Unknown error in KarafWatcher", e );
+      } finally {
+        serviceTracker.close();
       }
     }
   }


### PR DESCRIPTION
Transient=true

We should to close the tracker because we need to shutdown framework before the app shutdown for clear cache folder. The runned service tracker causes the problem during shutdown.
please see https://issues.apache.org/jira/browse/FELIX-971