### PR TITLE
[CLEANUP] - jasmine version upgrade is causing build to fail.  The ji…

### DIFF
--- a/pentaho-notification-webservice-bundle/pom.xml
+++ b/pentaho-notification-webservice-bundle/pom.xml
@@ -90,7 +90,7 @@
       <plugin>
         <groupId>com.github.searls</groupId>
         <artifactId>jasmine-maven-plugin</artifactId>
-        <version>2.2</version>
+        <version>1.3.1.6</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
…ra case attached to the upgrade was PPP-3559, which is about upgrading angular, not jasmine.  reverting the version change fixes the build