### PR TITLE
[SP-2974] - CLEANUP - jasmine version upgrade is causing build to fai…

### DIFF
--- a/pentaho-notification-webservice-bundle/pom.xml
+++ b/pentaho-notification-webservice-bundle/pom.xml
@@ -89,7 +89,7 @@
       <plugin>
         <groupId>com.github.searls</groupId>
         <artifactId>jasmine-maven-plugin</artifactId>
-        <version>2.2</version>
+        <version>1.3.1.6</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
…l.  The jira case attached to the upgrade was PPP-3559, which is about upgrading angular, not jasmine.  reverting the version change fixes the build

@pamval, here is backport of https://github.com/pentaho/pentaho-osgi-bundles/pull/161/files to 6.1. Thanks. 