### PR TITLE
[CLEANUP] Allows disabling minification

### DIFF
--- a/pentaho-webjars-deployer/src/main/java/org/pentaho/osgi/platform/webjars/WebjarsUrlHandler.java
+++ b/pentaho-webjars-deployer/src/main/java/org/pentaho/osgi/platform/webjars/WebjarsUrlHandler.java
@@ -27,8 +27,13 @@ import java.net.URLConnection;
  * Created by nbaker on 9/6/14.
  */
 public class WebjarsUrlHandler extends AbstractURLStreamHandlerService {
+  private boolean minificationEnabled;
+
+  public WebjarsUrlHandler( boolean minificationEnabled ) {
+    this.minificationEnabled = minificationEnabled;
+  }
 
   @Override public URLConnection openConnection( URL url ) throws IOException {
-    return new WebjarsURLConnection( new URL( url.getPath() ) );
+    return new WebjarsURLConnection( new URL( url.getPath() ), this.minificationEnabled );
   }
 }

--- a/pentaho-webjars-deployer/src/main/java/org/pentaho/osgi/platform/webjars/WebjarsUrlHandler.java
+++ b/pentaho-webjars-deployer/src/main/java/org/pentaho/osgi/platform/webjars/WebjarsUrlHandler.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright 2014 Pentaho Corporation. All rights reserved.
+ * Copyright 2014-2017 Pentaho Corporation. All rights reserved.
  */
 
 package org.pentaho.osgi.platform.webjars;

--- a/pentaho-webjars-deployer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/pentaho-webjars-deployer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
+           http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+  <!-- START: Configuration -->
+  <cm:property-placeholder persistent-id="org.pentaho.osgi.platform.webjars" update-strategy="none">
+    <cm:default-properties>
+      <cm:property name="webjars.minification.enabled" value="true"/>
+    </cm:default-properties>
+  </cm:property-placeholder>
+  <!-- END: Configuration -->
+
   <bean id="webjarsDeploymentListener" class="org.pentaho.osgi.platform.webjars.PentahoWebjarsTransformer" />
 
   <service ref="webjarsDeploymentListener" auto-export="interfaces" />
@@ -9,7 +20,10 @@
     <service-properties>
       <entry key="url.handler.protocol" value="pentaho-webjars" />
     </service-properties>
-    <bean class="org.pentaho.osgi.platform.webjars.WebjarsUrlHandler"/>
+
+    <bean class="org.pentaho.osgi.platform.webjars.WebjarsUrlHandler">
+      <argument value="${webjars.minification.enabled}"/>
+    </bean>
   </service>
 
 </blueprint>

--- a/pentaho-webjars-deployer/src/test/java/org/pentaho/osgi/platform/webjars/PentahoWebjarsTransformerTest.java
+++ b/pentaho-webjars-deployer/src/test/java/org/pentaho/osgi/platform/webjars/PentahoWebjarsTransformerTest.java
@@ -34,7 +34,7 @@ public class PentahoWebjarsTransformerTest {
     URL.setURLStreamHandlerFactory( new URLStreamHandlerFactory() {
       @Override public URLStreamHandler createURLStreamHandler( String protocol ) {
         if("pentaho-webjars".equals(protocol)){
-          return new WebjarsUrlHandler();
+          return new WebjarsUrlHandler( true );
         }
         return null;
       }

--- a/pentaho-webjars-deployer/src/test/java/org/pentaho/osgi/platform/webjars/PentahoWebjarsTransformerTest.java
+++ b/pentaho-webjars-deployer/src/test/java/org/pentaho/osgi/platform/webjars/PentahoWebjarsTransformerTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright 2014 Pentaho Corporation. All rights reserved.
+ * Copyright 2014-2017 Pentaho Corporation. All rights reserved.
  */
 
 package org.pentaho.osgi.platform.webjars;

--- a/pentaho-webjars-deployer/src/test/java/org/pentaho/osgi/platform/webjars/WebjarsURLConnectionTest.java
+++ b/pentaho-webjars-deployer/src/test/java/org/pentaho/osgi/platform/webjars/WebjarsURLConnectionTest.java
@@ -38,6 +38,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -64,7 +65,7 @@ public class WebjarsURLConnectionTest {
 
   @Test
   public void testClassicWebjarPomConfig() throws IOException, ParseException {
-    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars/smart-table/2.0.3-1" ) );
+    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars/smart-table/2.0.3-1" ), true );
 
     verifyManifest( zipInputStream );
     verifyBlueprint( zipInputStream, "smart-table/2.0.3-1" );
@@ -73,7 +74,7 @@ public class WebjarsURLConnectionTest {
 
   @Test
   public void testNoSourceFolder() throws IOException, ParseException {
-    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars/smart-table/2.0.3-1-no-source-folder" ) );
+    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars/smart-table/2.0.3-1-no-source-folder" ), true );
 
     verifyManifest( zipInputStream );
     verifyNoRequireJson( zipInputStream );
@@ -82,7 +83,7 @@ public class WebjarsURLConnectionTest {
 
   @Test
   public void testNoResourceFolder() throws IOException, ParseException {
-    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars/smart-table/2.0.3-1-no-resource-folder" ) );
+    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars/smart-table/2.0.3-1-no-resource-folder" ), true );
 
     verifyManifest( zipInputStream );
     verifyNoRequireJson( zipInputStream );
@@ -91,7 +92,7 @@ public class WebjarsURLConnectionTest {
 
   @Test
   public void testClassicWebjarScriptedConfig() throws IOException, ParseException {
-    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars/jquery/2.2.1" ) );
+    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars/jquery/2.2.1" ), true );
 
     verifyManifest( zipInputStream );
     verifyBlueprint( zipInputStream, "jquery/2.2.1" );
@@ -100,7 +101,7 @@ public class WebjarsURLConnectionTest {
 
   @Test
   public void testNpmWebjar() throws IOException, ParseException {
-    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars.npm/asap/2.0.3" ) );
+    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars.npm/asap/2.0.3" ), true );
 
     verifyManifest( zipInputStream );
     verifyBlueprint( zipInputStream, "asap/2.0.3" );
@@ -109,7 +110,7 @@ public class WebjarsURLConnectionTest {
 
   @Test
   public void testBowerWebjar() throws IOException, ParseException {
-    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars.bower/angular-ui-router.stateHelper/1.3.1" ) );
+    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars.bower/angular-ui-router.stateHelper/1.3.1" ), true );
 
     verifyManifest( zipInputStream );
     verifyBlueprint( zipInputStream, "angular-ui-router.stateHelper/1.3.1" );
@@ -118,7 +119,7 @@ public class WebjarsURLConnectionTest {
 
   @Test
   public void testMalformedWebjarFallback() throws IOException, ParseException {
-    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars/angular-dateparser/1.0.9" ) );
+    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars/angular-dateparser/1.0.9" ), true );
 
     verifyManifest( zipInputStream );
     verifyBlueprint( zipInputStream, "angular-dateparser/1.0.9" );
@@ -127,7 +128,7 @@ public class WebjarsURLConnectionTest {
 
   @Test
   public void testClosingStream() throws IOException {
-    WebjarsURLConnection connection = new WebjarsURLConnection( new URL( "mvn:org.webjars/angular-dateparser/1.0.9" ) );
+    WebjarsURLConnection connection = new WebjarsURLConnection( new URL( "mvn:org.webjars/angular-dateparser/1.0.9" ), false );
     connection.connect();
 
     InputStream inputStream = connection.getInputStream();
@@ -143,7 +144,7 @@ public class WebjarsURLConnectionTest {
 
   @Test( expected = IOException.class )
   public void testInputStreamException() throws IOException {
-    WebjarsURLConnection connection = new WebjarsURLConnection( new URL( "mvn:org.webjars/angular-dateparser/1.0.9xx" ) );
+    WebjarsURLConnection connection = new WebjarsURLConnection( new URL( "mvn:org.webjars/angular-dateparser/1.0.9xx" ), false );
     connection.connect();
 
     connection.getInputStream();
@@ -151,7 +152,7 @@ public class WebjarsURLConnectionTest {
 
   @Test
   public void testMinifiedResources() throws IOException, ParseException {
-    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars/smart-table/2.0.3-1" ) );
+    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars/smart-table/2.0.3-1" ), true );
 
     verifyBlueprint( zipInputStream, "smart-table/2.0.3-1" );
 
@@ -160,11 +161,54 @@ public class WebjarsURLConnectionTest {
 
   @Test
   public void testFailedMinification() throws IOException, ParseException {
-    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars/smart-table/2.0.3-1-fail-minification" ) );
+    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars/smart-table/2.0.3-1-fail-minification" ), true );
 
     verifyBlueprint( zipInputStream, "smart-table/2.0.3-1" );
 
     verifyNotMinified( zipInputStream, "smart-table/2.0.3-1", "smart-table.js" );
+  }
+
+  @Test
+  public void testDisabledMinification() throws IOException, ParseException {
+    ZipFile zipInputStream = getDeployedJar( new URL( "mvn:org.webjars/smart-table/2.0.3-1" ), false );
+
+    ZipEntry entry = zipInputStream.getEntry( "OSGI-INF/blueprint/blueprint.xml" );
+    assertNotNull( entry );
+
+    String bpFile = IOUtils.toString( zipInputStream.getInputStream( entry ), "UTF-8" );
+
+    Pattern distPattern = Pattern.compile( "<bean id=\"resourceMappingDist\".*>.*" +
+        "<property name=\"alias\" value=\"\\/smart-table/2.0.3-1\"\\/>.*" +
+        "<property name=\"path\" value=\"\\/META-INF\\/resources\\/dist-gen\"\\/>.*" +
+        "<\\/bean>", Pattern.DOTALL );
+
+    Matcher matcher = distPattern.matcher( bpFile );
+
+    assertFalse( "blueprint.xml shouldn't include path for minified smart-table", matcher.find() );
+
+    distPattern = Pattern.compile( "<bean id=\"resourceMappingSrc\".*>.*" +
+        "<property name=\"alias\" value=\"\\/webjar-src\\/smart-table/2.0.3-1\"\\/>.*" +
+        "<property name=\"path\" value=\"\\/META-INF\\/resources\\/webjars\\/smart-table/2.0.3-1\"\\/>.*" +
+        "<\\/bean>", Pattern.DOTALL );
+
+    matcher = distPattern.matcher( bpFile );
+
+    assertFalse( "blueprint.xml shouldn't include path for smart-table sources", matcher.find() );
+
+    distPattern = Pattern.compile( "<bean id=\"resourceMappingDist\".*>.*" +
+        "<property name=\"alias\" value=\"\\/smart-table/2.0.3-1\"\\/>.*" +
+        "<property name=\"path\" value=\"\\/META-INF\\/resources\\/webjars\\/smart-table/2.0.3-1\"\\/>.*" +
+        "<\\/bean>", Pattern.DOTALL );
+
+    matcher = distPattern.matcher( bpFile );
+
+    assertTrue( "blueprint.xml should include path for original smart-table", matcher.find() );
+
+    entry = zipInputStream.getEntry( "META-INF/resources/dist-gen/smart-table.js" );
+    assertNull( entry );
+
+    entry = zipInputStream.getEntry( "META-INF/resources/webjars/smart-table/2.0.3-1/smart-table.js");
+    assertNotNull( entry );
   }
 
   private void verifyManifest( ZipFile zipInputStream ) throws IOException {
@@ -258,8 +302,8 @@ public class WebjarsURLConnectionTest {
     assertEquals( minFile, srcFile );
   }
 
-  private ZipFile getDeployedJar( URL webjar_url ) throws IOException {
-    WebjarsURLConnection connection = new WebjarsURLConnection( webjar_url );
+  private ZipFile getDeployedJar( URL webjar_url, boolean minificationEnabled ) throws IOException {
+    WebjarsURLConnection connection = new WebjarsURLConnection( webjar_url, minificationEnabled );
     connection.connect();
 
     InputStream inputStream = connection.getInputStream();


### PR DESCRIPTION
Webjar's javascript files minification have a significant impact when booting for the first time / with clean karaf caches.

| `time` | Empty caches, minification enabled | Empty caches, minification disabled | Full caches |
| --- | --- | --- | --- |
| real      | **1m 48.354s** | **1m  7.967s** | 0m 35.578s |
| user     | 3m 46.528s | 2m  9.372s | 1m 26.942s |
| sys       | 0m 20.522s | 0m 17.746s | 0m  5.418s |

It can become a little painful at development time when needing to restart the software a few times.

This PR adds a configuration property that allows disabling the minification. Webjars will be deployed only with its original source files.

# How to use
- Create and edit the file `system/karaf/etc/org.pentaho.osgi.platform.webjars.cfg`
- Write `webjars.minification.enabled=false` and save
- Reboot the software with clean caches

To revert to the default behaviour just delete `system/karaf/etc/org.pentaho.osgi.platform.webjars.cfg` or change the `webjars.minification.enabled` value to `true`.

@pentaho/millenniumfalcon, @pamval please review and check if this is ok to enter.