### PR TITLE
[BACKLOG-14815] - Ensuring order in plugin file processing

### DIFF
--- a/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/PluginZipFileProcessor.java
+++ b/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/PluginZipFileProcessor.java
@@ -41,6 +41,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.Stack;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -187,7 +189,22 @@ public class PluginZipFileProcessor {
           }
 
           if ( currentFile.isDirectory() ) {
-            File[] dirFiles = currentFile.listFiles();
+            File[] dirFiles = currentFile.listFiles( );
+            //Ensure plugin.xml is always the first file to be handled, otherwise plugin metadata will be incomplete
+            //for the other plugin handlers
+            //Since we're pushing to a stack, plugin.xml is the last entry in this array
+            Arrays.sort( dirFiles, new Comparator<File>() {
+              @Override
+              public int compare( File o1, File o2 ) {
+                if ( "plugin.xml".equals( o1.getName() ) ) {
+                  return 100;
+                }
+                if ( "plugin.xml".equals( o2.getName() ) ) {
+                  return -100;
+                }
+                return o2.compareTo( o1 );
+              }
+            } );
             for ( File file : dirFiles ) {
               fileStack.push( file );
             }


### PR DESCRIPTION
Plugin file handlers need to be executed in order. PluginXmlPluginIdHandler needs to execute before SpringFileHandler. Otherwise, the bundle name in ManifestUpdater is not set appropriately and service registration fails (alias /content/analyzer/service is registered as /content/null/service).

Execution order for the handlers is determined by the order of the files being processed.
We were assuming that listFiles returns the files in alphabetical order (maybe, not sure what we assumed). This might not be true.
I forced an order to the files being processed by ensuring plugin.xml is always the first file.


@DFieldFL, please take a look. Not sure if this is the ideal fix, but it could help.