### PR TITLE
[BACKLOG-14815] In order to set the service entry point the bundle na…

### DIFF
--- a/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/PlatformPluginDeploymentListener.java
+++ b/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/PlatformPluginDeploymentListener.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -39,6 +39,7 @@ import java.util.zip.ZipFile;
  */
 public class PlatformPluginDeploymentListener implements ArtifactUrlTransformer {
   public static final String PROTOCOL = "pentaho-platform-plugin-file";
+  public static final String PLUGIN_XML_FILENAME = "plugin.xml";
   private Logger logger = LoggerFactory.getLogger( PlatformPluginDeploymentListener.class );
   private URLFactory urlFactory = new URLFactory() {
     @Override public URL create( String protocol, String file ) throws MalformedURLException {
@@ -65,7 +66,7 @@ public class PlatformPluginDeploymentListener implements ArtifactUrlTransformer 
       Enumeration<? extends ZipEntry> entries = zipFile.entries();
       while ( entries.hasMoreElements() ) {
         String[] splitName = entries.nextElement().getName().split( "/" );
-        if ( splitName.length == 2 && "plugin.xml".equals( splitName[ 1 ] ) ) {
+        if ( splitName.length == 2 && PLUGIN_XML_FILENAME.equals( splitName[ 1 ] ) ) {
           return true;
         }
       }

--- a/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/PluginZipFileProcessor.java
+++ b/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/PluginZipFileProcessor.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -50,6 +50,8 @@ import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
+
+import static org.pentaho.osgi.platform.plugin.deployer.PlatformPluginDeploymentListener.PLUGIN_XML_FILENAME;
 
 /**
  * Created by bryan on 8/28/14.
@@ -188,8 +190,20 @@ public class PluginZipFileProcessor {
 
           if ( currentFile.isDirectory() ) {
             File[] dirFiles = currentFile.listFiles();
+            File pluginXmlFile = null;
             for ( File file : dirFiles ) {
+              if ( PLUGIN_XML_FILENAME.equals( file.getName() ) ) {
+                pluginXmlFile = file;
+                continue;
+              }
               fileStack.push( file );
+            }
+
+            // Ensures the plugin.xml file is read before plugin.spring.xml. This is needed so
+            // {@link org.pentaho.osgi.platform.plugin.deployer.impl.handlers.SpringFileHandler#handle()}
+            // can get the proper bundleName and set the service entry point.
+            if ( null != pluginXmlFile ) {
+              fileStack.push( pluginXmlFile );
             }
           }
         }

--- a/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/handlers/PluginXmlFileHandler.java
+++ b/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/handlers/PluginXmlFileHandler.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,12 +22,9 @@
 
 package org.pentaho.osgi.platform.plugin.deployer.impl.handlers;
 
-import org.pentaho.osgi.platform.plugin.deployer.api.PluginHandlingException;
-import org.pentaho.osgi.platform.plugin.deployer.api.PluginMetadata;
 import org.pentaho.osgi.platform.plugin.deployer.api.XmlPluginFileHandler;
-import org.w3c.dom.Node;
 
-import java.util.List;
+import static org.pentaho.osgi.platform.plugin.deployer.PlatformPluginDeploymentListener.PLUGIN_XML_FILENAME;
 
 /**
  * Created by bryan on 8/29/14.
@@ -39,7 +36,7 @@ public abstract class PluginXmlFileHandler extends XmlPluginFileHandler {
   @Override public boolean handles( String fileName ) {
     if ( fileName != null ) {
       String[] splitName = fileName.split( "/" );
-      if ( splitName.length == 2 && "plugin.xml".equals( splitName[ 1 ] ) ) {
+      if ( splitName.length == 2 && PLUGIN_XML_FILENAME.equals( splitName[ 1 ] ) ) {
         return true;
       }
     }


### PR DESCRIPTION
…me is needed as part of the plugin.spring.xml. In Ubuntu 14.04 the plugin.xml was being read after the plugin.spring.xml file, which caused the bundle name to be null. Forcing plugin.xml to be read first so this does not happen.