### PR TITLE
[BACKLOG-15451] Modified the zookeeper fragment bundle to specify

### DIFF
--- a/pentaho-zookeeper-fragment/pom.xml
+++ b/pentaho-zookeeper-fragment/pom.xml
@@ -38,13 +38,6 @@
   <packaging>bundle</packaging>
   <properties>
   </properties>
-  <dependencies>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-    </dependency>
-  </dependencies>
   <build>
     <finalName>${project.artifactId}</finalName>
     <plugins>
@@ -56,7 +49,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Import-Package>org.apache.log4j</Import-Package>
+            <DynamicImport-Package>*</DynamicImport-Package>
             <Fragment-Host>org.apache.hadoop.zookeeper</Fragment-Host>
           </instructions>
         </configuration>


### PR DESCRIPTION
DynamicImport-Package * instead of explicitly specifying log4j as it is
looking for other dependencies like javax.security etc.