### PR TITLE
[BACKLOG-15657] - Setting the last modified property to a sane value at the beginning of the manager creation.

### DIFF
--- a/pentaho-requirejs-osgi-manager/src/main/java/org/pentaho/js/require/RequireJsConfigManager.java
+++ b/pentaho-requirejs-osgi-manager/src/main/java/org/pentaho/js/require/RequireJsConfigManager.java
@@ -64,7 +64,7 @@ public class RequireJsConfigManager {
   private BundleContext bundleContext;
 
   private volatile ConcurrentHashMap<String, Future<String>> cachedConfigurations;
-  private volatile long lastModified;
+  private volatile long lastModified = System.currentTimeMillis();
 
   private RequireJsBundleListener bundleListener;
 


### PR DESCRIPTION
There are some cases (edge / IE) where the last modified property is being checked before any update to the caches is done. This breaks the browsers caching mechanism. Setting the last modified property to a sane value at the manager's creation fixes the issue.

@pentaho/millenniumfalcon @nantunes please review