### PR TITLE
[BACKLOG-15674] Karaf Startup - plaftom-plugin-deployer is unnecessar…

### DIFF
--- a/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/handlers/BlueprintFileHandler.java
+++ b/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/handlers/BlueprintFileHandler.java
@@ -1,3 +1,25 @@
+/*!
+ * PENTAHO CORPORATION PROPRIETARY AND CONFIDENTIAL
+ *
+ * Copyright 2002 - 2017 Pentaho Corporation (Pentaho). All rights reserved.
+ *
+ * NOTICE: All information including source code contained herein is, and
+ * remains the sole property of Pentaho and its licensors. The intellectual
+ * and technical concepts contained herein are proprietary and confidential
+ * to, and are trade secrets of Pentaho and may be covered by U.S. and foreign
+ * patents, or patents in process, and are protected by trade secret and
+ * copyright laws. The receipt or possession of this source code and/or related
+ * information does not convey or imply any rights to reproduce, disclose or
+ * distribute its contents, or to manufacture, use, or sell anything that it
+ * may describe, in whole or in part. Any reproduction, modification, distribution,
+ * or public display of this information without the express written authorization
+ * from Pentaho is strictly prohibited and in violation of applicable laws and
+ * international treaties. Access to the source code contained herein is strictly
+ * prohibited to anyone except those individuals and entities who have executed
+ * confidentiality and non-disclosure agreements or other agreements with Pentaho,
+ * explicitly covering such access.
+ */
+
 package org.pentaho.osgi.platform.plugin.deployer.impl.handlers;
 
 import org.pentaho.osgi.platform.plugin.deployer.api.PluginFileHandler;
@@ -17,15 +39,17 @@ public class BlueprintFileHandler implements PluginFileHandler {
 
   public static final Pattern LIB_PATTERN = Pattern.compile( ".+\\/OSGI-INF\\/blueprint\\/.*\\.xml" );
   public static final String JAR = ".jar";
+  public static final String XML = ".xml";
+  public static final String OSGI_INF_BLUEPRINT = "OSGI-INF/blueprint/";
 
   @Override public boolean handles( String fileName ) {
-    return LIB_PATTERN.matcher( fileName ).matches();
+    return fileName != null && fileName.contains( OSGI_INF_BLUEPRINT ) && fileName.endsWith( XML );
   }
 
   @Override public void handle( String relativePath, File file, PluginMetadata pluginMetadata )
       throws PluginHandlingException {
     try ( FileReader fileReader = new FileReader( file );
-          FileWriter fileWriter = pluginMetadata.getFileWriter( relativePath.substring( relativePath.indexOf( "/" ) + 1 ) ); ) {
+          FileWriter fileWriter = pluginMetadata.getFileWriter( relativePath.substring( relativePath.indexOf( "/" ) + 1 ) ) ) {
       int read;
       while ( ( read = fileReader.read() ) != -1 ) {
         fileWriter.write( read );

--- a/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/handlers/ManifestFileHandler.java
+++ b/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/handlers/ManifestFileHandler.java
@@ -1,3 +1,23 @@
+/*
+ * ******************************************************************************
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ * ******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.pentaho.osgi.platform.plugin.deployer.impl.handlers;
 
 import org.pentaho.osgi.platform.plugin.deployer.api.PluginFileHandler;
@@ -14,9 +34,10 @@ public class ManifestFileHandler implements PluginFileHandler {
 
   public static final Pattern LIB_PATTERN = Pattern.compile( ".+\\/lib\\/.+\\.jar"  );
   public static final String JAR = ".jar";
+  public static final String LIB = "/lib/";
 
   @Override public boolean handles( String fileName ) {
-    return LIB_PATTERN.matcher( fileName ).matches();
+    return fileName != null && fileName.contains( LIB ) && fileName.endsWith( JAR );
   }
 
   @Override public void handle( String relativePath, File file, PluginMetadata pluginMetadata )

--- a/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/handlers/PluginLibraryFileHandler.java
+++ b/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/handlers/PluginLibraryFileHandler.java
@@ -1,7 +1,7 @@
 /*
  * ******************************************************************************
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  * ******************************************************************************
  *
@@ -46,9 +46,10 @@ public class PluginLibraryFileHandler implements PluginFileHandler {
 
   public static final Pattern LIB_PATTERN = Pattern.compile( ".+\\/lib\\/.+\\.jar"  );
   public static final String JAR = ".jar";
+  public static final String LIB = "/lib/";
 
   @Override public boolean handles( String fileName ) {
-    return LIB_PATTERN.matcher( fileName ).matches();
+    return fileName != null && fileName.contains( LIB ) && fileName.endsWith( JAR );
   }
 
   @Override public void handle( String relativePath, File file, PluginMetadata pluginMetadata )

--- a/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/handlers/PluginXmlFileHandler.java
+++ b/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/handlers/PluginXmlFileHandler.java
@@ -24,22 +24,17 @@ package org.pentaho.osgi.platform.plugin.deployer.impl.handlers;
 
 import org.pentaho.osgi.platform.plugin.deployer.api.XmlPluginFileHandler;
 
-import static org.pentaho.osgi.platform.plugin.deployer.PlatformPluginDeploymentListener.PLUGIN_XML_FILENAME;
-
 /**
  * Created by bryan on 8/29/14.
  */
 public abstract class PluginXmlFileHandler extends XmlPluginFileHandler {
+
+  public static final String PLUGIN_XML_FILENAME = "plugin.xml";
+
   public PluginXmlFileHandler( String xpath ) {
     super( xpath );
   }
   @Override public boolean handles( String fileName ) {
-    if ( fileName != null ) {
-      String[] splitName = fileName.split( "/" );
-      if ( splitName.length == 2 && PLUGIN_XML_FILENAME.equals( splitName[ 1 ] ) ) {
-        return true;
-      }
-    }
-    return false;
+    return fileName != null && fileName.endsWith( "/" + PLUGIN_XML_FILENAME );
   }
 }

--- a/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/handlers/SpringFileHandler.java
+++ b/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/handlers/SpringFileHandler.java
@@ -1,7 +1,7 @@
 /*!
  * PENTAHO CORPORATION PROPRIETARY AND CONFIDENTIAL
  *
- * Copyright 2002 - 2016 Pentaho Corporation (Pentaho). All rights reserved.
+ * Copyright 2002 - 2017 Pentaho Corporation (Pentaho). All rights reserved.
  *
  * NOTICE: All information including source code contained herein is, and
  * remains the sole property of Pentaho and its licensors. The intellectual
@@ -53,15 +53,20 @@ public class SpringFileHandler implements PluginFileHandler {
   public static final String LIB_PATTERN = ".+\\/lib\\/.+\\.jar";
   public static final String PLUGIN_SPRING_XML = ".+\\/plugin.spring.xml";
   private final Pattern beanPattern = Pattern.compile( ".*id=\"(.+?)\".+[(\\r\\n|\\r|\\n)]*" );
+  public static final String PLUGIN_SPRING_XML_FILENAME = "plugin.spring.xml";
+  public static final String LIB = "/lib/";
+  public static final String JAR = ".jar";
+  public static final String XML = ".xml";
 
   @Override public boolean handles( String fileName ) {
-    return fileName.matches( LIB_PATTERN ) || fileName.matches( PLUGIN_SPRING_XML );
+    return fileName != null
+            && ( ( fileName.contains( LIB ) && fileName.endsWith( JAR ) ) || fileName.endsWith( PLUGIN_SPRING_XML_FILENAME ) );
   }
 
   @Override public void handle( String relativePath, File file, PluginMetadata pluginMetadata )
     throws PluginHandlingException {
 
-    if ( relativePath.matches( LIB_PATTERN ) ) {
+    if ( relativePath.contains( LIB ) && relativePath.endsWith( JAR ) ) {
 
       FileInputStream fin = null;
       JarInputStream jarInputStream = null;
@@ -72,7 +77,7 @@ public class SpringFileHandler implements PluginFileHandler {
         ZipEntry nextEntry;
         while ( ( nextEntry = jarInputStream.getNextEntry() ) != null ) {
           String name = nextEntry.getName();
-          if ( name.matches( ".+\\.xml" ) ) {
+          if ( name.endsWith( XML ) ) {
             // have to crack it open unfortunately.
             //
             ByteArrayOutputStream byteArrayOutputStream = null;


### PR DESCRIPTION
…ily checking every file in the plugins

- applied the optimization work done a while back by @CodeOnCoffee @ https://github.com/pentaho/pentaho-osgi-bundles/pull/196/files
- in addition: listfiles now has a fileFilter that checks if the file is actually handle-able by some pluginHandler as the acceptance criteria to be added to the filestack 