### PR TITLE
[BACKLOG-15673] Added bundleListener that is listening for Bundle

### DIFF
--- a/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/PlatformPluginMavenURLHandler.java
+++ b/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/PlatformPluginMavenURLHandler.java
@@ -1,7 +1,30 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
 package org.pentaho.osgi.platform.plugin.deployer;
 
 import org.osgi.service.url.AbstractURLStreamHandlerService;
 import org.pentaho.osgi.platform.plugin.deployer.api.PluginFileHandler;
+import org.pentaho.osgi.platform.plugin.deployer.impl.BundleStateManager;
 
 import java.io.IOException;
 import java.net.URL;
@@ -13,13 +36,17 @@ import java.util.List;
  */
 public class PlatformPluginMavenURLHandler extends AbstractURLStreamHandlerService {
   private List<PluginFileHandler> pluginFileHandlers;
+  private BundleStateManager bundleStateManager;
 
   public void setPluginFileHandlers( List<PluginFileHandler> pluginFileHandlers ) {
     this.pluginFileHandlers = pluginFileHandlers;
   }
+  public void setBundleStateManager( BundleStateManager bundleStateManager ) {
+    this.bundleStateManager = bundleStateManager;
+  }
 
   @Override public URLConnection openConnection( URL u ) throws IOException {
     URL mvnUrl = new URL( "mvn", null, u.getPath() );
-    return new PlatformPluginBundlingURLConnection( mvnUrl, pluginFileHandlers );
+    return new PlatformPluginBundlingURLConnection( mvnUrl, pluginFileHandlers, bundleStateManager );
   }
 }

--- a/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/PlatformPluginURLHandler.java
+++ b/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/PlatformPluginURLHandler.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -24,6 +24,7 @@ package org.pentaho.osgi.platform.plugin.deployer;
 
 import org.osgi.service.url.AbstractURLStreamHandlerService;
 import org.pentaho.osgi.platform.plugin.deployer.api.PluginFileHandler;
+import org.pentaho.osgi.platform.plugin.deployer.impl.BundleStateManager;
 
 import java.io.IOException;
 import java.net.URL;
@@ -35,9 +36,14 @@ import java.util.List;
  */
 public class PlatformPluginURLHandler extends AbstractURLStreamHandlerService {
   private List<PluginFileHandler> pluginFileHandlers;
+  private BundleStateManager bundleStateManager;
 
   public void setPluginFileHandlers( List<PluginFileHandler> pluginFileHandlers ) {
     this.pluginFileHandlers = pluginFileHandlers;
+  }
+
+  public void setBundleStateManager( BundleStateManager bundleStateManager ) {
+    this.bundleStateManager = bundleStateManager;
   }
 
   @Override public URLConnection openConnection( URL u ) throws IOException {

--- a/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/BundleStateManager.java
+++ b/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/BundleStateManager.java
@@ -1,0 +1,62 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.osgi.platform.plugin.deployer.impl;
+
+import org.osgi.framework.BundleEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.HashMap;
+/**
+ * Manager holds the map of installed bundles.Provides a method to query if the
+ * bundle name exist in the map.
+ */
+public class BundleStateManager {
+  private static Logger log = LoggerFactory.getLogger( BundleStateManager.class );
+  Map<String, Integer> bundleMap;
+
+
+  public BundleStateManager() {
+    bundleMap = new HashMap<String, Integer>();
+  }
+
+  public void setState( String name, int state ) {
+    log.debug( "BundleStateManager adding the state for bundle: {}, with state: {}", name, state );
+    bundleMap.put( name, state );
+  }
+
+  /**
+   * Returns true is the bundle is the name is present in the map
+   *  otherwise false
+   */
+  public boolean isBundleInstalled( String name ) {
+    if ( bundleMap.containsKey( name ) ) {
+      if ( bundleMap.get( name ) == BundleEvent.INSTALLED ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+}

--- a/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/ManifestUpdaterImpl.java
+++ b/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/ManifestUpdaterImpl.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -86,6 +86,8 @@ public class ManifestUpdaterImpl implements ManifestUpdater {
     mainAttributes.putValue( "Bundle-SymbolicName", bundleName != null ? bundleName : symbolicName );
     mainAttributes.putValue( "Bundle-Name", name );
     mainAttributes.putValue( "Bundle-Version", version );
+    //Custom attribute to recognize if this is platform plugin
+    mainAttributes.putValue( "Bundle-PlatformPluginName", symbolicName );
     mainAttributes
         .putValue( "Export-Service", join( getExportServices(), "," ) );
     mainAttributes

--- a/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/PlatformDeployerBundleListener.java
+++ b/pentaho-platform-plugin-deployer/src/main/java/org/pentaho/osgi/platform/plugin/deployer/impl/PlatformDeployerBundleListener.java
@@ -1,0 +1,77 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.osgi.platform.plugin.deployer.impl;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.BundleListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is a bundle listener that gets the callback whenever the bundle state changes.
+ * It stores the state of the only those bundle that have the manifest entry in header
+ * "Bundle-PlatformPluginName".
+ */
+
+public class PlatformDeployerBundleListener implements BundleListener {
+  private static Logger log = LoggerFactory.getLogger( PlatformDeployerBundleListener.class );
+  private BundleContext bundleContext;
+  private BundleStateManager bundleStateManager;
+
+  public void setBundleContext( BundleContext bundleContext ) {
+    this.bundleContext = bundleContext;
+  }
+
+  public void setBundleStateManager( BundleStateManager bundleStateManager ) {
+    this.bundleStateManager = bundleStateManager;
+  }
+
+  // For unit test only
+  static void setLog( Logger log ) {
+    PlatformDeployerBundleListener.log = log;
+  }
+
+  // For unit test only
+  static Logger getLog() {
+    return log;
+  }
+
+  @Override public void bundleChanged( BundleEvent event ) {
+    switch ( event.getType() ) {
+      case BundleEvent.UNINSTALLED:
+      case BundleEvent.INSTALLED:
+        //Check if the bundle is platformPluginBundle
+        if ( event.getBundle().getHeaders().get( "Bundle-PlatformPluginName" ) != null ) {
+          String bundleStr = event.getBundle().getHeaders().get( "Bundle-Name" ) +  event.getBundle().getHeaders().get( "Bundle-Version" );
+          log.info( "Received Bundle event : {}", bundleStr
+                + ( ( event.getType() == BundleEvent.INSTALLED ) ? "Installed" : "Uninstalled" ) );
+          bundleStateManager.setState( bundleStr, event.getType() );
+        }
+        break;
+    }
+  }
+
+  public void init() throws Exception {
+    bundleContext.addBundleListener( this );
+  }
+}

--- a/pentaho-platform-plugin-deployer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/pentaho-platform-plugin-deployer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -32,6 +32,7 @@
     </service-properties>
     <bean class="org.pentaho.osgi.platform.plugin.deployer.PlatformPluginMavenURLHandler">
       <property name="pluginFileHandlers" ref="pluginFileHandlers"/>
+      <property name="bundleStateManager" ref="bundleStateManager"/>
     </bean>
   </service>
 
@@ -75,6 +76,11 @@
     <bean class="org.pentaho.osgi.platform.plugin.deployer.impl.handlers.pluginxml.PluginXmlPluginIdHandler"/>
   </service>
 
+  <bean id="platformDeployerBundleListener" class="org.pentaho.osgi.platform.plugin.deployer.impl.PlatformDeployerBundleListener" scope="singleton" init-method="init">
+    <property name="bundleContext" ref="blueprintBundleContext"/>
+    <property name="bundleStateManager" ref="bundleStateManager"/>
+  </bean>
+  <bean id="bundleStateManager" class="org.pentaho.osgi.platform.plugin.deployer.impl.BundleStateManager"/>
 
   <reference-list id="pluginFileHandlers" interface="org.pentaho.osgi.platform.plugin.deployer.api.PluginFileHandler" availability="optional" />
 </blueprint>

--- a/pentaho-platform-plugin-deployer/src/test/java/org/pentaho/osgi/platform/plugin/deployer/impl/BundleStateManagerTest.java
+++ b/pentaho-platform-plugin-deployer/src/test/java/org/pentaho/osgi/platform/plugin/deployer/impl/BundleStateManagerTest.java
@@ -1,0 +1,54 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.osgi.platform.plugin.deployer.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.BundleEvent;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created on 4/5/2017.
+ */
+public class BundleStateManagerTest {
+  BundleStateManager bundleStateManager;
+  public static final String BUNDLE_COMMON_UI = "common-ui307";
+
+  @Before
+  public void setup() {
+    bundleStateManager = new BundleStateManager();
+  }
+
+  @Test
+  public void testIsBundleInstalled() {
+    //Set the state to installed
+    bundleStateManager.setState( BUNDLE_COMMON_UI, BundleEvent.INSTALLED );
+    assertTrue( bundleStateManager.isBundleInstalled( BUNDLE_COMMON_UI ) );
+
+    //Set the state to Uninstalled
+    bundleStateManager.setState( BUNDLE_COMMON_UI, BundleEvent.UNINSTALLED );
+    assertFalse( bundleStateManager.isBundleInstalled( BUNDLE_COMMON_UI ) );
+  }
+
+}

--- a/pentaho-platform-plugin-deployer/src/test/java/org/pentaho/osgi/platform/plugin/deployer/impl/PlatformDeployerBundleListenerTest.java
+++ b/pentaho-platform-plugin-deployer/src/test/java/org/pentaho/osgi/platform/plugin/deployer/impl/PlatformDeployerBundleListenerTest.java
@@ -1,0 +1,83 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.osgi.platform.plugin.deployer.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created on 4/5/2017.
+ */
+public class PlatformDeployerBundleListenerTest {
+  private Bundle bundle;
+  private BundleEvent bundleEvent;
+  private BundleContext bundleContext;
+  private BundleStateManager bundleStateManager;
+  private PlatformDeployerBundleListener platformDeployerBundleListener;
+
+  @Before
+  public void setup() {
+    bundleEvent = mock( BundleEvent.class );
+    bundle = mock( Bundle.class );
+    bundleContext = mock( BundleContext.class );
+    when( bundleEvent.getBundle() ).thenReturn( bundle );
+    when( bundleContext.getBundle() ).thenReturn( bundle );
+    bundleStateManager =  new BundleStateManager();
+    platformDeployerBundleListener = new PlatformDeployerBundleListener();
+    platformDeployerBundleListener.setBundleStateManager( bundleStateManager );
+    platformDeployerBundleListener.setBundleContext( bundleContext );
+    when( bundleEvent.getBundle().getSymbolicName() ).thenReturn( "common-ui" );
+    Dictionary<String, String> headers = new Hashtable<String, String>();
+    headers.put( "Bundle-Name",  "common-ui" );
+    headers.put( "Bundle-Version",  "100" );
+    headers.put( "Bundle-PlatformPluginName",  "common-ui" );
+    when( bundleEvent.getBundle().getHeaders() ).thenReturn( headers );
+  }
+
+  @Test
+  public void testBundleInstalled() {
+    when( bundleEvent.getType() ).thenReturn( BundleEvent.INSTALLED );
+    when( bundleEvent.getBundle().getState() ).thenReturn( BundleEvent.INSTALLED );
+    platformDeployerBundleListener.bundleChanged( bundleEvent );
+    assertTrue( bundleStateManager.isBundleInstalled( "common-ui100" ) );
+  }
+
+  @Test
+  public void testBundleUninstalled() {
+    when( bundleEvent.getType() ).thenReturn( BundleEvent.UNINSTALLED );
+    when( bundleEvent.getBundle().getState() ).thenReturn( BundleEvent.UNINSTALLED );
+    platformDeployerBundleListener.bundleChanged( bundleEvent );
+    assertFalse( bundleStateManager.isBundleInstalled( "common-ui100" ) );
+  }
+
+}

--- a/pentaho-platform-plugin-deployer/src/test/java/org/pentaho/osgi/platform/plugin/deployer/impl/PluginZipFileProcessorTest.java
+++ b/pentaho-platform-plugin-deployer/src/test/java/org/pentaho/osgi/platform/plugin/deployer/impl/PluginZipFileProcessorTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -69,7 +69,7 @@ public class PluginZipFileProcessorTest {
   public void testProcessBackgroundWithException() throws IOException {
     List<PluginFileHandler> pluginFileHandlers = new ArrayList<PluginFileHandler>();
     PluginZipFileProcessor pluginZipFileProcessor =
-      new PluginZipFileProcessor( pluginFileHandlers, "test", "test-symbolic", "version" );
+      new PluginZipFileProcessor( pluginFileHandlers, false, "test", "test-symbolic", "version" );
     ZipOutputStream zipOutputStream = mock( ZipOutputStream.class );
     ZipInputStream zipInputStream = mock( ZipInputStream.class );
     ExceptionSettable<IOException> exceptionSettable = mock( ExceptionSettable.class );
@@ -84,7 +84,7 @@ public class PluginZipFileProcessorTest {
   public void testProcessBackgroundWithNoException() throws IOException {
     List<PluginFileHandler> pluginFileHandlers = new ArrayList<PluginFileHandler>();
     PluginZipFileProcessor pluginZipFileProcessor =
-      new PluginZipFileProcessor( pluginFileHandlers, "test", "test-symbolic", "version" );
+      new PluginZipFileProcessor( pluginFileHandlers, false, "test", "test-symbolic", "version" );
     ZipOutputStream zipOutputStream = mock( ZipOutputStream.class );
     ZipInputStream zipInputStream = mock( ZipInputStream.class );
     ExceptionSettable<IOException> exceptionSettable = mock( ExceptionSettable.class );
@@ -96,7 +96,7 @@ public class PluginZipFileProcessorTest {
   public void testProcess() throws IOException {
     List<PluginFileHandler> pluginFileHandlers = new ArrayList<PluginFileHandler>();
     PluginZipFileProcessor pluginZipFileProcessor =
-      new PluginZipFileProcessor( pluginFileHandlers, "test", "test-symbolic", "version" );
+      new PluginZipFileProcessor( pluginFileHandlers, false, "test", "test-symbolic", "version" );
     ZipOutputStream zipOutputStream = mock( ZipOutputStream.class );
     pluginZipFileProcessor.process( new ZipInputStream( this.getClass().getClassLoader()
         .getResourceAsStream( "org/pentaho/osgi/platform/plugin/deployer/testCanHandleWithPluginXmlOneDirDown.zip" ) ),
@@ -115,7 +115,7 @@ public class PluginZipFileProcessorTest {
   public void testProcessCloseExceptions() throws IOException {
     List<PluginFileHandler> pluginFileHandlers = new ArrayList<PluginFileHandler>();
     PluginZipFileProcessor pluginZipFileProcessor =
-      new PluginZipFileProcessor( pluginFileHandlers, "test", "test-symbolic", "version" );
+      new PluginZipFileProcessor( pluginFileHandlers, false, "test", "test-symbolic", "version" );
     ZipInputStream zipInputStream = mock( ZipInputStream.class );
     ZipOutputStream zipOutputStream = mock( ZipOutputStream.class );
     pluginZipFileProcessor.process( zipInputStream, zipOutputStream );
@@ -128,7 +128,7 @@ public class PluginZipFileProcessorTest {
     List<PluginFileHandler> pluginFileHandlers =
       new ArrayList<PluginFileHandler>( Arrays.asList( new PluginXmlStaticPathsHandler() ) );
     PluginZipFileProcessor pluginZipFileProcessor =
-      new PluginZipFileProcessor( pluginFileHandlers, "test", "test-symbolic", "version" );
+      new PluginZipFileProcessor( pluginFileHandlers, false, "test", "test-symbolic", "version" );
     ZipOutputStream zipOutputStream = mock( ZipOutputStream.class );
     pluginZipFileProcessor.process( new ZipInputStream( this.getClass().getClassLoader()
         .getResourceAsStream( "org/pentaho/osgi/platform/plugin/deployer/testWithManifestAndBlueprint.zip" ) ),
@@ -158,4 +158,19 @@ public class PluginZipFileProcessorTest {
       return argument instanceof ZipEntry && name.equals( ( (ZipEntry) argument ).getName() );
     }
   }
+
+  @Test
+  public void testProcessManifest() throws IOException {
+    List<PluginFileHandler> pluginFileHandlers =
+      new ArrayList<PluginFileHandler>( Arrays.asList( new PluginXmlStaticPathsHandler() ) );
+
+    ZipOutputStream zipOutputStream = mock( ZipOutputStream.class );
+    ZipInputStream zipInputStream = mock( ZipInputStream.class );
+    PluginZipFileProcessor pluginZipFileProcessor =
+      new PluginZipFileProcessor( pluginFileHandlers, true, "test", "test-symbolic", "version" );
+    pluginZipFileProcessor.processManifest( zipOutputStream );
+    verify( zipOutputStream, times( 1 ) )
+      .putNextEntry( argThat( new ZipEntryMatcher( new ZipEntry( JarFile.MANIFEST_NAME ) ) ) );
+  }
+
 }


### PR DESCRIPTION
installed and uninstalled event and store the state of bundle in
BundleStateManager. PluginZipFileProcessor will only processes the
common-ui if it is not installed. Any subsequent call, it will create a
manifest and return.

 - Cleaned up and applied more checkstyle fixes

 - Added unit test for BundleStateManager and PlatformDeployerBundleListener