### PR TITLE
[BACKLOG-17171]-[DEV] - Use existing the Metastore locator to find

### DIFF
--- a/pentaho-metastore-locator/impl/local/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/pentaho-metastore-locator/impl/local/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+   
+    <bean id="localMetastoreProvider" class="org.pentaho.osgi.metastore.locator.impl.local.LocalFileMetastoreProvider" scope="singleton" />
+    <service ref="localMetastoreProvider" interface="org.pentaho.osgi.metastore.locator.api.MetastoreProvider" ranking="150"/>
+
+</blueprint>


### PR DESCRIPTION
NameCluster