### PR TITLE
[PPP-3807] Use of vulnerable component camel-blueprint-2.14.3.jar CVE…

### DIFF
--- a/pentaho-camel-guava-eventbus/README.md
+++ b/pentaho-camel-guava-eventbus/README.md
@@ -1,0 +1,11 @@
+This OSGi bundle simply wraps camel-guava-eventbus-2.17.7.jar artifact
+with the reason to override version of com.google.common.eventbus package being imported (force it to be 17.x).
+This is needed due to inability of using guava's EventBus in blueprint container starting from guava-18.0.
+
+Considering there are no breaking changes in 18.0 and 19.0 releases of Guava eventbus,
+that could affect camel-guava-eventbus, we need to downgrade guava to be able to use it in Blueprint context.
+
+EventBus instance can't be injected from a reference, since the Blueprint container must proxy it.
+The container generates a subclass at runtime to be able to proxy a class.
+This has the limitation of not being able to work on final classes or final methods.
+And starting from guava-18.0 version, the EventBus class does have final methods.

--- a/pentaho-camel-guava-eventbus/pom.xml
+++ b/pentaho-camel-guava-eventbus/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>pentaho</groupId>
+    <artifactId>pentaho-osgi-bundles</artifactId>
+    <version>8.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>pentaho-camel-guava-eventbus</artifactId>
+  <version>8.0-SNAPSHOT</version>
+  <packaging>bundle</packaging>
+  <name>Pentaho Community Edition Project: ${project.artifactId}</name>
+  <description>
+    This OSGi bundle simply wraps camel-guava-eventbus-2.17.7.jar artifact
+    with the reason to override version of com.google.common.eventbus package being imported (force it to be 17.x).
+    This is needed due to inability of using guava's EventBus in blueprint container starting from guava-18.0.
+
+    Considering there are no breaking changes in 18.0 and 19.0 releases of Guava eventbus,
+    that could affect camel-guava-eventbus, we need to downgrade guava to be able to use it in Blueprint context.
+
+    EventBus instance can't be injected from a reference, since the Blueprint container must proxy it.
+    The container generates a subclass at runtime to be able to proxy a class.
+    This has the limitation of not being able to work on final classes or final methods.
+    And starting from guava-18.0 version, the EventBus class does have final methods.
+  </description>
+  <url>http://www.pentaho.com</url>
+
+  <properties>
+    <camel.guava.eventbus.version>2.17.7</camel.guava.eventbus.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-guava-eventbus</artifactId>
+      <version>${camel.guava.eventbus.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <includes>
+                  <include>org.apache.camel:camel-guava-eventbus</include>
+                </includes>
+              </artifactSet>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.3.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-Name>${project.artifactId}</Bundle-Name>
+            <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+            <Export-Package>org.apache.camel.component.guava.eventbus;uses:="org.apache.camel,org.apache.camel.util,org.slf4j,com.google.common.eventbus,org.apache.camel.impl,org.apache.camel.spi";version="${camel.guava.eventbus.version}"</Export-Package>
+            <Export-Service>org.apache.camel.spi.ComponentResolver;component=guava-eventbus</Export-Service>
+            <Import-Package>com.google.common.eventbus;version="[17.0,18)",org.apache.camel;version="[2.17,2.18)",org.apache.camel.impl;version="[2.17,2.18)",org.apache.camel.spi;version="[2.17,2.18)",org.apache.camel.util;version="[2.17,2.18)",org.osgi.framework;version="[1.5,2)",org.osgi.framework.wiring;version="[1.0,2)",org.slf4j;version="[1.6,2)"</Import-Package>
+            <Implementation-Title>Apache Camel</Implementation-Title>
+            <Implementation-Version>${camel.guava.eventbus.version}</Implementation-Version>
+            <Karaf-Info>Camel;camel-guava-eventbus=${camel.guava.eventbus.version}</Karaf-Info>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
         <module>pentaho-pdi-platform</module>
         <module>pentaho-object-tunnel</module>
         <module>pentaho-zookeeper-fragment</module>
+        <module>pentaho-camel-guava-eventbus</module>
       </modules>
       <distributionManagement>
         <site>
@@ -194,6 +195,7 @@
         <module>pentaho-kettle-repository-locator</module>
         <module>pentaho-metastore-locator</module>
         <module>pentaho-pdi-platform</module>
+        <module>pentaho-camel-guava-eventbus</module>
       </modules>
       <distributionManagement>
         <site>


### PR DESCRIPTION
…-2017-5643 CVE-2017-3159 CVE-2015-5348 CVE-2015-5344

 - added pentaho-camel-guava-eventbus module which wraps camel-guava-eventbus only overriding its dependecies