### PR TITLE
[CLEANUP] Cleaning up module profiles because wingman was failing due…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,57 +93,10 @@
   </build>
   <profiles>
     <profile>
-      <id>all</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <modules>
-        <module>pentaho-blueprint-collection-utils</module>
-        <module>angular-bundle</module>
-        <module>pentaho-i18n-bundle</module>
-        <module>pentaho-i18n-webservice-bundle</module>
-        <module>pentaho-notification-bundle</module>
-        <module>pentaho-notification-webservice-bundle</module>
-        <module>pentaho-platform-plugin-deployer</module>
-        <module>pentaho-requirejs-utils</module>
-        <module>pentaho-requirejs-osgi-manager</module>
-        <module>pentaho-webpackage</module>
-        <module>pentaho-webjars-deployer</module>
-        <module>pentaho-osgi-utils-api</module>
-        <module>pentaho-osgi-utils-impl</module>
-        <module>pentaho-service-coordinator</module>
-        <module>pentaho-capability-manager</module>
-        <module>pentaho-cache-manager</module>
-        <module>pentaho-server-bundle</module>
-        <module>pentaho-proxy-factory</module>
-        <module>pentaho-proxy-spring4</module>
-        <module>pentaho-authentication-mapper</module>
-        <module>pentaho-kettle-repository-locator</module>
-        <module>pentaho-metastore-locator</module>
-        <module>pentaho-bundle-resource-manager</module>
-        <module>pentaho-spring-dm-extender</module>
-        <module>pentaho-pdi-platform</module>
-        <module>pentaho-object-tunnel</module>
-        <module>pentaho-zookeeper-fragment</module>
-        <module>pentaho-camel-guava-eventbus</module>
-      </modules>
-      <distributionManagement>
-        <site>
-          <id>pentaho.public.snapshot.repo</id>
-          <name>${project.artifactId}-${project.version}-all</name>
-          <url>dav:${site.publish.url}/${project.groupId}/pentaho-osgi-bundles-all-${project.version}</url>
-        </site>
-      </distributionManagement>
-      <properties>
-        <sonar.projectName>${project.artifactId}-all</sonar.projectName>
-        <sonar.projectKey>${project.groupId}:${project.artifactId}-all</sonar.projectKey>
-      </properties>
-    </profile>
-    <profile>
       <id>lowdeps</id>
       <activation>
         <property>
-          <name>lowdeps</name>
+          <name>!skipDefault</name>
         </property>
       </activation>
       <modules>
@@ -168,23 +121,12 @@
         <module>pentaho-zookeeper-fragment</module>
         <module>pentaho-bundle-resource-manager</module>
       </modules>
-      <distributionManagement>
-        <site>
-          <id>pentaho.public.snapshot.repo</id>
-          <name>${project.artifactId}-${project.version}-lowdeps</name>
-          <url>dav:${site.publish.url}/${project.groupId}/pentaho-osgi-bundles-lowdeps-${project.version}</url>
-        </site>
-      </distributionManagement>
-      <properties>
-        <sonar.projectName>${project.artifactId}-lowdeps</sonar.projectName>
-        <sonar.projectKey>${project.groupId}:${project.artifactId}-lowdeps</sonar.projectKey>
-      </properties>
     </profile>
     <profile>
       <id>highdeps</id>
       <activation>
         <property>
-          <name>highdeps</name>
+          <name>!skipDefault</name>
         </property>
       </activation>
       <modules>
@@ -197,17 +139,6 @@
         <module>pentaho-pdi-platform</module>
         <module>pentaho-camel-guava-eventbus</module>
       </modules>
-      <distributionManagement>
-        <site>
-          <id>pentaho.public.snapshot.repo</id>
-          <name>${project.artifactId}-${project.version}-highdeps</name>
-          <url>dav:${site.publish.url}/${project.groupId}/pentaho-osgi-bundles-highdeps-${project.version}</url>
-        </site>
-      </distributionManagement>
-      <properties>
-        <sonar.projectName>${project.artifactId}-highdeps</sonar.projectName>
-        <sonar.projectKey>${project.groupId}:${project.artifactId}-highdeps</sonar.projectKey>
-      </properties>
     </profile>
     <profile>
       <id>aggregate-reporting</id>


### PR DESCRIPTION
@smaring @graimundo 

Was causing wingman to fail after [this](https://github.com/pentaho/pentaho-osgi-bundles/commit/279adb834694930beb3f1ce9dabe1510c254bc9c) change. That reporting profile would get activated and disable the "all" profile because of the activeByDefault activation.

Build resources updates:
https://github.com/pentaho/build-resources/pull/152
https://github.com/pentaho/build-resources/pull/153
https://github.com/pentaho/build-resources/pull/154
https://github.com/pentaho/build-resources/pull/155
https://github.com/pentaho/build-resources/pull/156
https://github.com/pentaho/build-resources/pull/157
https://github.com/pentaho/build-resources/pull/158
https://github.com/pentaho/build-resources/pull/159
https://github.com/pentaho/build-resources/pull/160