### PR TITLE
Revert "[BACKLOG-22526] vulnerable component spring-security: upgrade from 4.…"

### DIFF
--- a/pentaho-proxy-spring4/pom.xml
+++ b/pentaho-proxy-spring4/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <springframework.version>4.3.2.RELEASE</springframework.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <springsecurity.version>4.1.5.RELEASE</springsecurity.version>
+    <springsecurity.version>4.1.3.RELEASE</springsecurity.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Reverts pentaho/pentaho-osgi-bundles#264

@pentaho/rogueone @pamval @dkincade @mbatchelor @mdamour1976 @graimundo

**List or PRs**

- https://github.com/pentaho/marketplace/pull/149
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/37
- https://github.com/pentaho/pentaho-metadata-editor/pull/124
- https://github.com/pentaho/pentaho-kettle/pull/5275
- https://github.com/pentaho/pentaho-platform/pull/4111
- https://github.com/pentaho/pentaho-platform-ee/pull/1266
- https://github.com/pentaho/pentaho-karaf-assembly/pull/441
- https://github.com/pentaho/pdi-ee-plugin/pull/357
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/107
- https://github.com/pentaho/pentaho-reporting/pull/1134
- https://github.com/pentaho/pentaho-osgi-bundles/pull/265
