### PR TITLE
[BACKLOG-22526] Use of vulnerable component spring-security 4.1.3 CVE…

### DIFF
--- a/pentaho-proxy-spring4/pom.xml
+++ b/pentaho-proxy-spring4/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <springframework.version>4.3.2.RELEASE</springframework.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <springsecurity.version>4.1.3.RELEASE</springsecurity.version>
+    <springsecurity.version>4.1.5.RELEASE</springsecurity.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
…-2018-1199

**Minor patch upgrade**: from `4.1.3 RELEASE` to `4.1.5 RELEASE`

@pentaho/rogueone
CC'ing @pamval @dkincade @mbatchelor @mdamour1976 @graimundo

~Please **hold off** merging until we have triggered a PR for all necessary projects~ ✅ 

List of PRs:
- https://github.com/pentaho/pentaho-platform/pull/4229
- https://github.com/pentaho/pentaho-osgi-bundles/pull/288
- https://github.com/pentaho/pentaho-platform-ee/pull/1276
- https://github.com/pentaho/pentaho-kettle/pull/5750
- https://github.com/pentaho/pentaho-reporting/pull/1179
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/115
- https://github.com/pentaho/pdi-ee-plugin/pull/361
- https://github.com/pentaho/pentaho-karaf-assembly/pull/478
- https://github.com/pentaho/pentaho-metadata-editor/pull/128
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/38
- https://github.com/pentaho/marketplace/pull/152