### PR TITLE
[BACKLOG-22526][CLEANUP] Promoting current spring-security.version to…

### DIFF
--- a/pentaho-proxy-spring4/pom.xml
+++ b/pentaho-proxy-spring4/pom.xml
@@ -16,7 +16,6 @@
   <properties>
     <springframework.version>4.3.2.RELEASE</springframework.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <springsecurity.version>4.1.5.RELEASE</springsecurity.version>
   </properties>
   <dependencies>
     <dependency>
@@ -111,12 +110,12 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>${springsecurity.version}</version>
+      <version>${spring-security.version}</version> <!-- see maven-parent-pom -->
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>${springsecurity.version}</version>
+      <version>${spring-security.version}</version> <!-- see maven-parent-pom -->
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>


### PR DESCRIPTION
… maven-parent-pom

**Notes**
- This is not changing the current version
  - we are merely promoting it to maven-parent-pom as a cleanup + centralization effort
- Wingman **will** fail on these
  - the referenced dependency property version `spring-security.version` is not yet in play 
  - see related PR adding it to maven-parent-pom: https://github.com/pentaho/maven-parent-poms/pull/71

@pentaho/rogueone @pentaho-lmartins

~Please **hold off** merging until we have triggered a PR for all necessary projects~ ✅

**List of PRs:**
- https://github.com/pentaho/maven-parent-poms/pull/71
- https://github.com/pentaho/marketplace/pull/153
- https://github.com/pentaho/pentaho-platform/pull/4231
- https://github.com/pentaho/pentaho-platform-ee/pull/1278
- https://github.com/pentaho/pentaho-kettle/pull/5752
- https://github.com/pentaho/pentaho-reporting/pull/1181
- https://github.com/pentaho/pdi-ee-plugin/pull/362
- https://github.com/pentaho/pentaho-osgi-bundles/pull/289
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/40
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/116
- https://github.com/pentaho/pentaho-metadata-editor/pull/130
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/40