### PR TITLE
[BACKLOG-27577] Centralize karaf dependencies management

### DIFF
--- a/pentaho-osgi-utils-api/pom.xml
+++ b/pentaho-osgi-utils-api/pom.xml
@@ -19,8 +19,6 @@
     <dependency>
       <groupId>org.apache.karaf.bundle</groupId>
       <artifactId>org.apache.karaf.bundle.core</artifactId>
-      <version>${karaf.version}</version>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>

--- a/pentaho-osgi-utils-impl/pom.xml
+++ b/pentaho-osgi-utils-impl/pom.xml
@@ -53,14 +53,10 @@
     <dependency>
       <groupId>org.apache.karaf.features</groupId>
       <artifactId>org.apache.karaf.features.core</artifactId>
-      <version>${karaf.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.karaf.bundle</groupId>
       <artifactId>org.apache.karaf.bundle.core</artifactId>
-      <version>${karaf.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pentaho-platform-plugin-deployer/pom.xml
+++ b/pentaho-platform-plugin-deployer/pom.xml
@@ -30,7 +30,6 @@
     <dependency>
       <groupId>org.apache.karaf</groupId>
       <artifactId>org.apache.karaf.util</artifactId>
-      <version>${karaf.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
     <commons-lang.version>2.6</commons-lang.version>
     <rxjava.version>2.2.3</rxjava.version>
     <platform.version>8.3.0.0-SNAPSHOT</platform.version>
-    <karaf.version>3.0.3</karaf.version>
     <spring-security.version>4.1.5.RELEASE</spring-security.version>
 
     <!-- All 3 of these properties are required -->


### PR DESCRIPTION
@graimundo and @Pancho7 please review.

Note that this targets pentaho:karaf_update, so wingman will not run. Our build pipeline will, when all related PRs are merged.

Needs [pentaho/maven-parent-poms#107](https://github.com/pentaho/maven-parent-poms/pull/107).