### PR TITLE
[PDI-17775] Process Files step no longer supports HTTP scheme

### DIFF
--- a/pentaho-pdi-platform/src/main/java/org/pentaho/platform/pdi/vfs/MetadataToMondrianVfs.java
+++ b/pentaho-pdi-platform/src/main/java/org/pentaho/platform/pdi/vfs/MetadataToMondrianVfs.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+* Copyright (c) 2002-2019 Hitachi Vantara..  All rights reserved.
 */
 
 package org.pentaho.platform.pdi.vfs;
@@ -22,7 +22,7 @@ import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemConfigBuilder;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
-import org.apache.commons.vfs2.provider.FileProvider;
+import org.apache.commons.vfs2.provider.AbstractFileProvider;
 
 import java.util.Collection;
 
@@ -32,7 +32,7 @@ import java.util.Collection;
  *
  * @author Will Gorman (wgorman@pentaho.com)
  */
-public class MetadataToMondrianVfs implements FileProvider {
+public class MetadataToMondrianVfs extends AbstractFileProvider {
 
   public MetadataToMondrianVfs() {
     super();
@@ -52,22 +52,26 @@ public class MetadataToMondrianVfs implements FileProvider {
     return null;
   }
 
+  @Override
   public FileObject createFileSystem( final String arg0, final FileObject arg1, final FileSystemOptions arg2 )
     throws FileSystemException {
     // not needed for our usage
     return null;
   }
 
+  @Override
   public FileSystemConfigBuilder getConfigBuilder() {
     // not needed for our usage
     return null;
   }
 
+  @Override
   public Collection getCapabilities() {
     // not needed for our usage
     return null;
   }
 
+  @Override
   public FileName parseUri( final FileName arg0, final String arg1 ) throws FileSystemException {
     // not needed for our usage
     return null;


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @ssamora @wseyler 

* [PDI-17775] Updating file to extend AbstractFileProvider instead of implementing FileProvider (compatability for commons-vfs2-2.3). Extending also implements FileProvider.

This is a multi-pull request, please see: pentaho/pentaho-kettle#6316