### PR TITLE
[PPP-4400] Use of Vulnerable Component: logback-classic-1.1.11.jar (CVE-2017-5929)

### DIFF
--- a/pentaho-requirejs-compressor/pom.xml
+++ b/pentaho-requirejs-compressor/pom.xml
@@ -37,7 +37,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.13</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @wseyler

* [PPP-4400] Remove version reference, letting maven-parent-poms handle it

This Pull Request is part of a series of Pull Requests:
- https://github.com/pentaho/maven-parent-poms/pull/145
- https://github.com/pentaho/pdi-osgi-bridge/pull/73
- https://github.com/pentaho/pdi-monitoring-plugin/pull/96
- https://github.com/pentaho/pentaho-ee/pull/2128
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/227
- https://github.com/pentaho/pentaho-osgi-bundles/pull/324