### PR TITLE
[SP-5147] Backport of PPP-4400 - Use of Vulnerable Component: logback-classic-1.1.11.jar (CVE-2017-5929) (8.3 Suite)

### DIFF
--- a/pentaho-requirejs-compressor/pom.xml
+++ b/pentaho-requirejs-compressor/pom.xml
@@ -37,7 +37,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.13</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @LeonardoCoelho71950 

This PR is a part of a set of PRs:
- https://github.com/pentaho/maven-parent-poms/pull/149
- https://github.com/pentaho/pdi-osgi-bridge/pull/76
- https://github.com/pentaho/pdi-monitoring-plugin/pull/97
- https://github.com/pentaho/adaptive-execution-layer/pull/5
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/228
- https://github.com/pentaho/pentaho-osgi-bundles/pull/325