### PR TITLE
[SP-5146] Backport of PPP-4400 - Use of Vulnerable Component: logback-classic-1.1.11.jar (CVE-2017-5929) (7.1 Suite)

### DIFF
--- a/pentaho-requirejs-compressor/pom.xml
+++ b/pentaho-requirejs-compressor/pom.xml
@@ -27,12 +27,11 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>${commons-io.version>}</version>
+      <version>${commons-io.version}</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.13</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pentaho-requirejs-compressor/src/main/java/org/pentaho/platform/osgi/requirejs/api/IAmdScriptSource.java
+++ b/pentaho-requirejs-compressor/src/main/java/org/pentaho/platform/osgi/requirejs/api/IAmdScriptSource.java
@@ -12,13 +12,14 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright 2014 Pentaho Corporation. All rights reserved.
+ * Copyright 2014 - 2019 Hitachi Vantara. All rights reserved.
  */
 
 package org.pentaho.platform.osgi.requirejs.api;
 
 
 import org.osgi.framework.Version;
+import org.pentaho.platform.osgi.requirejs.bindings.RequireJsConfig;
 
 /**
  * Created by nbaker on 10/1/14.


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @LeonardoCoelho71950

This PR is a part of a set of PRs (pentaho-ee was not backported as the relevant file was added in version 8.0+):

- pentaho/maven-parent-poms#150
- pentaho/pdi-osgi-bridge#77
- pentaho/pdi-monitoring-plugin#98
- pentaho/pentaho-karaf-ee-assembly#229
- #327 