### PR TITLE
[SP-5146] Backport of PPP-4400 - Use of Vulnerable Component: logback-classic-1.1.11.jar (CVE-2017-5929) (7.1 Suite)

### DIFF
--- a/pentaho-requirejs-utils/pom.xml
+++ b/pentaho-requirejs-utils/pom.xml
@@ -32,7 +32,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.13</version>
     </dependency>
     <dependency>
       <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @LeonardoCoelho71950 

* [SP-5146] Removing hard-coded version num for logback-classic