### PR TITLE
[PDI-17775] Process Files step no longer supports HTTP scheme

### DIFF
--- a/pentaho-pdi-platform/src/main/java/org/pentaho/platform/pdi/vfs/MetadataToMondrianVfs.java
+++ b/pentaho-pdi-platform/src/main/java/org/pentaho/platform/pdi/vfs/MetadataToMondrianVfs.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2019 Hitachi Vantara..  All rights reserved.
+* Copyright (c) 2002-2020 Hitachi Vantara..  All rights reserved.
 */
 
 package org.pentaho.platform.pdi.vfs;

--- a/pentaho-pdi-platform/src/main/java/org/pentaho/platform/pdi/vfs/MetadataToMondrianVfs.java
+++ b/pentaho-pdi-platform/src/main/java/org/pentaho/platform/pdi/vfs/MetadataToMondrianVfs.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+* Copyright (c) 2002-2019 Hitachi Vantara..  All rights reserved.
 */
 
 package org.pentaho.platform.pdi.vfs;
@@ -22,7 +22,7 @@ import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemConfigBuilder;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
-import org.apache.commons.vfs2.provider.FileProvider;
+import org.apache.commons.vfs2.provider.AbstractFileProvider;
 
 import java.util.Collection;
 
@@ -32,7 +32,7 @@ import java.util.Collection;
  *
  * @author Will Gorman (wgorman@pentaho.com)
  */
-public class MetadataToMondrianVfs implements FileProvider {
+public class MetadataToMondrianVfs extends AbstractFileProvider {
 
   public MetadataToMondrianVfs() {
     super();
@@ -52,22 +52,26 @@ public class MetadataToMondrianVfs implements FileProvider {
     return null;
   }
 
+  @Override
   public FileObject createFileSystem( final String arg0, final FileObject arg1, final FileSystemOptions arg2 )
     throws FileSystemException {
     // not needed for our usage
     return null;
   }
 
+  @Override
   public FileSystemConfigBuilder getConfigBuilder() {
     // not needed for our usage
     return null;
   }
 
+  @Override
   public Collection getCapabilities() {
     // not needed for our usage
     return null;
   }
 
+  @Override
   public FileName parseUri( final FileName arg0, final String arg1 ) throws FileSystemException {
     // not needed for our usage
     return null;


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @ssamora 

* [PDI-17775] Updating file to extend AbstractFileProvider instead of implementing FileProvider (compatability for commons-vfs2-2.3). Extending also implements FileProvider.

This PR is a part of a series of PR to upgrade commons-vfs2 and fix VFS issues with HTTP:
- https://github.com/pentaho/apache-vfs-browser/pull/60
- https://github.com/pentaho/big-data-plugin/pull/1929
- https://github.com/webdetails/cpk/pull/85
- https://github.com/pentaho/data-access/pull/1083
- https://github.com/pentaho/maven-parent-poms/pull/185
- https://github.com/pentaho/mondrian/pull/1177
- https://github.com/pentaho/pdi-jms-plugin/pull/73
- https://github.com/pentaho/pdi-platform-utils-plugin/pull/102
- https://github.com/pentaho/pdi-plugins-ee/pull/139
- https://github.com/pentaho/pdi-sap-hana-bulk-loader-plugin/pull/82
- https://github.com/pentaho/pdi-teradata-tpt-plugin/pull/51
- https://github.com/pentaho/pentaho-big-data-ee/pull/426
- https://github.com/pentaho/pentaho-commons-database/pull/177
- https://github.com/pentaho/pentaho-data-mining/pull/24
- https://github.com/pentaho/pentaho-det-ee/pull/608
- https://github.com/pentaho/pentaho-hdfs-vfs/pull/21
- https://github.com/pentaho/pentaho-karaf-assembly/pull/615
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/277
- https://github.com/pentaho/pentaho-kettle/pull/7130
- https://github.com/pentaho/pentaho-metaverse/pull/614
- https://github.com/pentaho/pentaho-osgi-bundles/pull/347
- https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1493
- https://github.com/pentaho/pentaho-platform-plugin-geo/pull/328
- https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/765
- https://github.com/pentaho/pentaho-platform/pull/4598
- https://github.com/pentaho/pentaho-reporting/pull/1305
- https://github.com/pentaho/pentaho-s3-vfs/pull/87
- https://github.com/pentaho/worker-nodes-ee-plugin/pull/14