### PR TITLE
[BACKLOG-33393] Adding Webpackage overrides for `@uirouter/core` and …

### DIFF
--- a/pentaho-webjars-deployer/src/main/resources/overrides/org.webjars.bower/angular-ui-router/0.4.2/overrides.json
+++ b/pentaho-webjars-deployer/src/main/resources/overrides/org.webjars.bower/angular-ui-router/0.4.2/overrides.json
@@ -1,8 +1,0 @@
-{
-  "shim": {
-    "angular-ui-router/release/angular-ui-router": {
-      "exports": "angular",
-      "deps": ["angular"]
-    }
-  }
-}

--- a/pentaho-webjars-deployer/src/main/resources/overrides/org.webjars.npm/uirouter__angularjs/1.0.22/overrides.json
+++ b/pentaho-webjars-deployer/src/main/resources/overrides/org.webjars.npm/uirouter__angularjs/1.0.22/overrides.json
@@ -1,0 +1,9 @@
+{
+  "packages": [
+    {
+      "name": "@uirouter/angularjs",
+      "location": "/release",
+      "main": "ui-router-angularjs.min"
+    }
+  ]
+}

--- a/pentaho-webjars-deployer/src/main/resources/overrides/org.webjars.npm/uirouter__core/5.0.23/overrides.json
+++ b/pentaho-webjars-deployer/src/main/resources/overrides/org.webjars.npm/uirouter__core/5.0.23/overrides.json
@@ -1,0 +1,9 @@
+{
+  "packages": [
+    {
+      "name": "@uirouter/core",
+      "location": "/_bundles",
+      "main": "ui-router-core.min"
+    }
+  ]
+}


### PR DESCRIPTION
…`@uirouter/angularjs` and removing the old bower version `angular-ui-router`.

@pentaho/millenniumfalcon please review.
/cc @pentaho/r2d2

Part of pentaho/maven-parent-poms#213.