### PR TITLE
[SP-5370] Backport of PDI-17775 - Process Files step no longer suppor…

### DIFF
--- a/pentaho-pdi-platform/src/main/java/org/pentaho/platform/pdi/vfs/MetadataToMondrianVfs.java
+++ b/pentaho-pdi-platform/src/main/java/org/pentaho/platform/pdi/vfs/MetadataToMondrianVfs.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+* Copyright (c) 2002-2020 Hitachi Vantara..  All rights reserved.
 */
 
 package org.pentaho.platform.pdi.vfs;
@@ -22,7 +22,7 @@ import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemConfigBuilder;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
-import org.apache.commons.vfs2.provider.FileProvider;
+import org.apache.commons.vfs2.provider.AbstractFileProvider;
 
 import java.util.Collection;
 
@@ -32,7 +32,7 @@ import java.util.Collection;
  *
  * @author Will Gorman (wgorman@pentaho.com)
  */
-public class MetadataToMondrianVfs implements FileProvider {
+public class MetadataToMondrianVfs extends AbstractFileProvider {
 
   public MetadataToMondrianVfs() {
     super();
@@ -52,22 +52,26 @@ public class MetadataToMondrianVfs implements FileProvider {
     return null;
   }
 
+  @Override
   public FileObject createFileSystem( final String arg0, final FileObject arg1, final FileSystemOptions arg2 )
     throws FileSystemException {
     // not needed for our usage
     return null;
   }
 
+  @Override
   public FileSystemConfigBuilder getConfigBuilder() {
     // not needed for our usage
     return null;
   }
 
+  @Override
   public Collection getCapabilities() {
     // not needed for our usage
     return null;
   }
 
+  @Override
   public FileName parseUri( final FileName arg0, final String arg1 ) throws FileSystemException {
     // not needed for our usage
     return null;


### PR DESCRIPTION
…ts HTTP scheme (9.0 Suite)

Cherry pick from: https://github.com/pentaho/pentaho-osgi-bundles/pull/347

This PR is part of a series of Pull Requests:
- https://github.com/pentaho/maven-parent-poms/pull/220
- https://github.com/pentaho/apache-vfs-browser/pull/61
- https://github.com/pentaho/big-data-plugin/pull/2035
- https://github.com/webdetails/cpk/pull/86
- https://github.com/pentaho/data-access/pull/1090
- https://github.com/pentaho/mondrian/pull/1197
- https://github.com/pentaho/pdi-jms-plugin/pull/75
- https://github.com/pentaho/pdi-platform-utils-plugin/pull/103
- https://github.com/pentaho/pdi-plugins-ee/pull/170
- https://github.com/pentaho/pdi-sap-hana-bulk-loader-plugin/pull/83
- https://github.com/pentaho/pdi-teradata-tpt-plugin/pull/52
- https://github.com/pentaho/pentaho-big-data-ee/pull/442
- https://github.com/pentaho/pentaho-commons-database/pull/178
- https://github.com/pentaho/pentaho-data-mining/pull/25
- https://github.com/pentaho/pentaho-det-ee/pull/615
- https://github.com/pentaho/pentaho-hdfs-vfs/pull/22
- https://github.com/pentaho/pentaho-karaf-assembly/pull/634
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/286
- https://github.com/pentaho/pentaho-kettle/pull/7313
- https://github.com/pentaho/pentaho-metaverse/pull/620
- https://github.com/pentaho/pentaho-osgi-bundles/pull/362
- https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1503
- https://github.com/pentaho/pentaho-platform-plugin-geo/pull/340
- https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/789
- https://github.com/pentaho/pentaho-platform/pull/4651
- https://github.com/pentaho/pentaho-reporting/pull/1328
- https://github.com/pentaho/pentaho-s3-vfs/pull/93
- https://github.com/pentaho/worker-nodes-ee-plugin/pull/16