### PR TITLE
[BACKLOG-35509] Use compiler target settings from parent pom.  Unit test

### DIFF
--- a/pentaho-platform-plugin-deployer/pom.xml
+++ b/pentaho-platform-plugin-deployer/pom.xml
@@ -57,6 +57,12 @@
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>xerces</groupId>
+      <artifactId>xercesImpl</artifactId>
+      <version>${xercesImpl.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <finalName>${project.artifactId}</finalName>

--- a/pentaho-platform-plugin-deployer/src/test/java/org/pentaho/osgi/platform/plugin/deployer/impl/handlers/pluginxml/PluginXmlStaticPathsHandlerTest.java
+++ b/pentaho-platform-plugin-deployer/src/test/java/org/pentaho/osgi/platform/plugin/deployer/impl/handlers/pluginxml/PluginXmlStaticPathsHandlerTest.java
@@ -16,7 +16,7 @@
  */
 package org.pentaho.osgi.platform.plugin.deployer.impl.handlers.pluginxml;
 
-import com.sun.org.apache.xerces.internal.dom.ElementNSImpl;
+import org.apache.xerces.dom.ElementNSImpl;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;


### PR DESCRIPTION
corrections to handle missing depedencies.