### PR TITLE
[PPP-5069] Vulnerable Component: Spring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <spring-kafka.version>1.3.10.RELEASE</spring-kafka.version>
     <protoc.version>3.11.4</protoc.version>
     <platform.version>10.2.0.0-SNAPSHOT</platform.version>
-    <spring53.bundle.version>5.3.33_1</spring53.bundle.version>
+    <spring53.bundle.version>5.3.34_1</spring53.bundle.version>
     <spring43.bundle.version>4.3.23.RELEASE_1</spring43.bundle.version>
     <spring32.bundle.version>3.2.18.RELEASE_1</spring32.bundle.version>
     <aspectj.bundle.version>1.7.4_1</aspectj.bundle.version>


### PR DESCRIPTION
Use 5.3.34_1

**NOTE:** This PR can only be merged after the Apache project releases the bundles for version 5.3.34 of Spring (which is not the case at the moment).

@renato-s @andreramos89 