### PR TITLE
[PPP-5163] Vulnerable Component: snakeyaml - part 2 ( Non OSGi upgrade)

### DIFF
--- a/pentaho-proxy-factory/pom.xml
+++ b/pentaho-proxy-factory/pom.xml
@@ -26,11 +26,6 @@
       <artifactId>org.osgi.compendium</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hitachivantara</groupId>
-      <artifactId>safeyaml</artifactId>
-      <version>${safeyaml.version}</version>
-    </dependency>
-    <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
       <version>2.6</version>


### PR DESCRIPTION
- removing unused dependnecy 'org.yaml:snakeyaml' from pentaho-proxy-factory