### PR TITLE
[SP-6624] Backport of PDI-20219 - Charts do not function in DET in 9.3.0.8 (9.3 Suite)

### DIFF
--- a/pentaho-pdi-platform/src/main/java/org/pentaho/platform/pdi/AgileBiAuthorizationPolicy.java
+++ b/pentaho-pdi-platform/src/main/java/org/pentaho/platform/pdi/AgileBiAuthorizationPolicy.java
@@ -31,7 +31,8 @@ public class AgileBiAuthorizationPolicy implements IAuthorizationPolicy {
 
   private static final List<String> ALLOWED_ACTIONS =
     Arrays.asList( "org.pentaho.repository.read", "org.pentaho.repository.create",
-      "org.pentaho.security.administerSecurity" );
+      "org.pentaho.security.administerSecurity", "org.pentaho.scheduler.manage",
+      "org.pentaho.platform.dataaccess.datasource.security.manage" );
 
   @Override public boolean isAllowed( String s ) {
     return true;

--- a/pentaho-pdi-platform/src/test/java/org/pentaho/platform/pdi/AgileBiAuthorizationPolicyTest.java
+++ b/pentaho-pdi-platform/src/test/java/org/pentaho/platform/pdi/AgileBiAuthorizationPolicyTest.java
@@ -40,7 +40,8 @@ public class AgileBiAuthorizationPolicyTest {
   public void getAllowedActions() throws Exception {
     assertThat( authorizationPolicy.getAllowedActions( "anything" ), equalTo( Arrays
       .asList( "org.pentaho.repository.read", "org.pentaho.repository.create",
-        "org.pentaho.security.administerSecurity" )));
+        "org.pentaho.security.administerSecurity", "org.pentaho.scheduler.manage",
+      "org.pentaho.platform.dataaccess.datasource.security.manage" )));
   }
 
 }


### PR DESCRIPTION
To note that this PR is not really a backport as the original error did not happen on master most probably due to the changes in the code line existing on both versions.

This is the fix for the 9.3 code line!

@pentaho/tatooine_dev 