### PR TITLE
[BACKLOG-41287]-Upgrading pentaho-osgi-bundles from Java EE to Jakarta EE to support with Tomcat-10.X

### DIFF
--- a/pentaho-pdi-platform/pom.xml
+++ b/pentaho-pdi-platform/pom.xml
@@ -16,7 +16,6 @@
   <properties>
     <mondrian.version>10.3.0.0-SNAPSHOT</mondrian.version>
     <pdi.version>10.3.0.0-SNAPSHOT</pdi.version>
-    <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <pentaho-metadata.version>10.3.0.0-SNAPSHOT</pentaho-metadata.version>
     <platform.version>10.3.0.0-SNAPSHOT</platform.version>
   </properties>
@@ -24,7 +23,7 @@
     <dependency>
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
-      <version>2.1.6</version>
+      <version>${jakarta.ws.rs-api.version}</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>


### PR DESCRIPTION
[BACKLOG-41287]-Upgrading pentaho-osgi-bundles from Java EE to Jakarta EE to support with Tomcat-10.X

[BACKLOG-41287]: https://hv-eng.atlassian.net/browse/BACKLOG-41287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ