### PR TITLE
[BACKLOG-42944] Provide external interface to read karaf config values so

### DIFF
--- a/pentaho-osgi-utils/api/src/main/java/org/pentaho/osgi/api/IKarafFeatureWatcher.java
+++ b/pentaho-osgi-utils/api/src/main/java/org/pentaho/osgi/api/IKarafFeatureWatcher.java
@@ -12,6 +12,9 @@
 
 package org.pentaho.osgi.api;
 
+import java.io.IOException;
+import java.util.List;
+
 /**
  * Interface defining a class which serves one purpose, block until all features defined in the Karaf featuresBoot are
  * installed.
@@ -21,6 +24,7 @@ package org.pentaho.osgi.api;
 public interface IKarafFeatureWatcher {
   void waitForFeatures() throws FeatureWatcherException;
 
+  List<String> getFeatures( String configPersistentId, String featuresPropertyKey ) throws IOException;
 
   class FeatureWatcherException extends Exception {
     public FeatureWatcherException( String message ) {

--- a/pentaho-osgi-utils/impl/src/main/java/org/pentaho/osgi/impl/KarafFeatureWatcherImpl.java
+++ b/pentaho-osgi-utils/impl/src/main/java/org/pentaho/osgi/impl/KarafFeatureWatcherImpl.java
@@ -210,7 +210,7 @@ public class KarafFeatureWatcherImpl implements IKarafFeatureWatcher {
    *         an empty list if the features property key is not mapped.
    * @throws IOException if access to persistent storage fails.
    */
-  protected List<String> getFeatures( String configPersistentId, String featuresPropertyKey ) throws IOException {
+  public List<String> getFeatures( String configPersistentId, String featuresPropertyKey ) throws IOException {
     Configuration configuration = this.getConfigurationAdmin().getConfiguration( configPersistentId );
 
     Dictionary<String, Object> properties = configuration.getProperties();
@@ -222,6 +222,8 @@ public class KarafFeatureWatcherImpl implements IKarafFeatureWatcher {
     if ( featuresPropertyValue == null ) {
       return Collections.emptyList();
     }
+
+    logger.debug( "Reading config {} property {} value {}", configPersistentId, featuresPropertyKey, featuresPropertyValue );
 
     // remove parentesis from feature stages
     featuresPropertyValue = featuresPropertyValue.replaceAll( "[()]", "" );


### PR DESCRIPTION
objects outside the OSGi framework (KarafLifecycleListener) can read config settings.