### PR TITLE
build[PPP-5751]: update GWT version to 2.12.2 and adjust groupId for GWT dependencies

### DIFF
--- a/pentaho-pdi-platform/pom.xml
+++ b/pentaho-pdi-platform/pom.xml
@@ -135,7 +135,7 @@
     <dependency>
       <groupId>org.gwtproject</groupId>
       <artifactId>gwt-servlet-jakarta</artifactId>
-      <version>${gwt-servlet-jakarta.version}</version>
+      <version>${gwt.version}</version>
     </dependency>
     <dependency>
       <groupId>pentaho-kettle</groupId>


### PR DESCRIPTION
**⚠️ Merge only after https://github.com/pentaho/maven-parent-poms/pull/761 has been merged ⚠️** 

This pull request includes a minor dependency update in the `pentaho-pdi-platform/pom.xml` file. The change updates the version reference for the `gwt-servlet-jakarta` dependency to use the `${gwt.version}` property instead of `${gwt-servlet-jakarta.version}`.