### PR TITLE
build[SP-6878]: update GWT version to 2.12.2 and adjust groupId for GWT dependencies

### DIFF
--- a/pentaho-pdi-platform/pom.xml
+++ b/pentaho-pdi-platform/pom.xml
@@ -138,9 +138,9 @@
       <version>5.3.34</version>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-servlet</artifactId>
-      <version>2.10.0</version>
+      <version>${gwt.version}</version>
     </dependency>
     <dependency>
       <groupId>pentaho-kettle</groupId>


### PR DESCRIPTION
build[PPP-5751]: update GWT version to 2.12.2 and adjust groupId for GWT dependencies (#544)

⚠️ This is slightly different from the original PR