### PR TITLE
fix(osgi-bundles): Fix the failures of the osgi-bundles integration tests [BACKLOG-50649]

### DIFF
--- a/pentaho-service-coordinator/src/test/java/org/pentaho/platform/servicecoordination/impl/CountdownLatchServiceLifecycleManagerTest.java
+++ b/pentaho-service-coordinator/src/test/java/org/pentaho/platform/servicecoordination/impl/CountdownLatchServiceLifecycleManagerTest.java
@@ -279,12 +279,19 @@ public class CountdownLatchServiceLifecycleManagerTest {
         completed.set( true );
       }
     } );
-    t2.start();
 
     int fatalCount = 0;
     do {
       Thread.sleep( 10 );
-    } while ( t1.getState() != Thread.State.WAITING && ++fatalCount < 10 );
+    } while ( t1.getState() != Thread.State.WAITING && ++fatalCount < 20 );
+    assertSame( "First operation should be waiting for the listener", Thread.State.WAITING, t1.getState() );
+    t2.start();
+
+    fatalCount = 0;
+    do {
+      t2.join( 10 );
+    } while ( t2.getState() != Thread.State.BLOCKED && ++fatalCount < 20 );
+    assertSame( "Second operation should be blocked by the first", Thread.State.BLOCKED, t2.getState() );
     assertFalse( completed.get() );
 
     latch.countDown();


### PR DESCRIPTION
This pull request improves the reliability and clarity of the thread state assertions in the `testBlockingOperations` test. The main changes ensure that thread states are properly checked and asserted before and after starting the threads, making the test more robust and easier to understand.

**Test reliability and clarity improvements:**

* Increased the retry limit when waiting for `t1` to enter the `WAITING` state and added an assertion to verify that `t1` is indeed waiting before starting `t2`.
* Changed the order of starting `t2` to occur after confirming `t1` is waiting, and added a loop with `join` and an assertion to verify that `t2` reaches the `BLOCKED` state, improving the accuracy of the test.